### PR TITLE
Add compiler option to swap out using module

### DIFF
--- a/lib/protobuf/protoc/cli.ex
+++ b/lib/protobuf/protoc/cli.ex
@@ -66,6 +66,11 @@ defmodule Protobuf.Protoc.CLI do
     parse_params(ctx, t)
   end
 
+  def parse_params(ctx, ["using_module=" <> using_module | t]) do
+    ctx = %{ctx | using_module: using_module}
+    parse_params(ctx, t)
+  end
+
   def parse_params(ctx, _), do: ctx
 
   @doc false

--- a/lib/protobuf/protoc/context.ex
+++ b/lib/protobuf/protoc/context.ex
@@ -32,7 +32,7 @@ defmodule Protobuf.Protoc.Context do
             custom_file_options: %{},
 
             # Allow custom code injection
-            using_module: Protobuf
+            using_module: "Protobuf"
 
   def cal_file_options(ctx, nil) do
     %{ctx | custom_file_options: %{}, module_prefix: ctx.package || ""}

--- a/lib/protobuf/protoc/context.ex
+++ b/lib/protobuf/protoc/context.ex
@@ -29,7 +29,10 @@ defmodule Protobuf.Protoc.Context do
             gen_descriptors?: false,
 
             # Elixirpb.FileOptions
-            custom_file_options: %{}
+            custom_file_options: %{},
+
+            # Allow custom code injection
+            using_module: Protobuf
 
   def cal_file_options(ctx, nil) do
     %{ctx | custom_file_options: %{}, module_prefix: ctx.package || ""}

--- a/lib/protobuf/protoc/generator/enum.ex
+++ b/lib/protobuf/protoc/generator/enum.ex
@@ -13,7 +13,14 @@ defmodule Protobuf.Protoc.Generator.Enum do
     generate_desc = if ctx.gen_descriptors?, do: desc, else: nil
     type = generate_type(desc.value)
 
-    Protobuf.Protoc.Template.enum(msg_name, msg_opts(ctx, desc), fields, type, generate_desc)
+    Protobuf.Protoc.Template.enum(
+      msg_name,
+      msg_opts(ctx, desc),
+      fields,
+      type,
+      generate_desc,
+      ctx.using_module
+    )
   end
 
   def generate_type(fields) do

--- a/lib/protobuf/protoc/generator/extension.ex
+++ b/lib/protobuf/protoc/generator/extension.ex
@@ -24,7 +24,7 @@ defmodule Protobuf.Protoc.Generator.Extension do
     else
       name = Util.trans_name(@ext_postfix)
       msg_name = Util.mod_name(ctx, ns ++ [name])
-      Protobuf.Protoc.Template.extension(msg_name, msg_opts(ctx, desc), extends)
+      Protobuf.Protoc.Template.extension(msg_name, msg_opts(ctx, desc), extends, ctx.using_module)
     end
   end
 

--- a/lib/protobuf/protoc/generator/message.ex
+++ b/lib/protobuf/protoc/generator/message.ex
@@ -34,7 +34,8 @@ defmodule Protobuf.Protoc.Generator.Message do
       fields: fields,
       oneofs: oneofs_str(desc.oneof_decl),
       desc: generate_desc,
-      extensions: extensions
+      extensions: extensions,
+      using_module: ctx.using_module
     }
   end
 
@@ -47,7 +48,8 @@ defmodule Protobuf.Protoc.Generator.Message do
       msg_struct[:oneofs],
       gen_fields(syntax, msg_struct[:fields]),
       msg_struct[:desc],
-      gen_extensions(msg_struct[:extensions])
+      gen_extensions(msg_struct[:extensions]),
+      msg_struct[:using_module]
     )
   end
 

--- a/lib/protobuf/protoc/template.ex
+++ b/lib/protobuf/protoc/template.ex
@@ -11,11 +11,25 @@ defmodule Protobuf.Protoc.Template do
     :def,
     :message,
     @msg_tmpl,
-    [:name, :options, :struct_fields, :typespec, :oneofs, :fields, :desc, :extensions],
+    [
+      :name,
+      :options,
+      :struct_fields,
+      :typespec,
+      :oneofs,
+      :fields,
+      :desc,
+      :extensions,
+      :using_module
+    ],
     trim: true
   )
 
-  EEx.function_from_file(:def, :enum, @enum_tmpl, [:name, :options, :fields, :type, :desc],
+  EEx.function_from_file(
+    :def,
+    :enum,
+    @enum_tmpl,
+    [:name, :options, :fields, :type, :desc, :using_module],
     trim: true
   )
 
@@ -23,5 +37,7 @@ defmodule Protobuf.Protoc.Template do
     trim: true
   )
 
-  EEx.function_from_file(:def, :extension, @ext_tmpl, [:name, :options, :extends], trim: true)
+  EEx.function_from_file(:def, :extension, @ext_tmpl, [:name, :options, :extends, :using_module],
+    trim: true
+  )
 end

--- a/priv/templates/enum.ex.eex
+++ b/priv/templates/enum.ex.eex
@@ -1,6 +1,6 @@
 defmodule <%= name %> do
   @moduledoc false
-  use <%= using_module %> <%= options %>
+  use <%= using_module %><%= options %>
 
   <%= type %>
 

--- a/priv/templates/enum.ex.eex
+++ b/priv/templates/enum.ex.eex
@@ -1,7 +1,7 @@
 defmodule <%= name %> do
   @moduledoc false
-  use Protobuf<%= options %>
-  
+  use <%= using_module %> <%= options %>
+
   <%= type %>
 
   <%= if not is_nil(desc) do %>

--- a/priv/templates/extension.ex.eex
+++ b/priv/templates/extension.ex.eex
@@ -1,6 +1,6 @@
 defmodule <%= name %> do
   @moduledoc false
-  use Protobuf<%= options %>
+  use <%= using_module %> <%= options %>
 
 <%= for ext <- extends do %>  extend <%= ext %>
 <% end %>

--- a/priv/templates/extension.ex.eex
+++ b/priv/templates/extension.ex.eex
@@ -1,6 +1,6 @@
 defmodule <%= name %> do
   @moduledoc false
-  use <%= using_module %> <%= options %>
+  use <%= using_module %><%= options %>
 
 <%= for ext <- extends do %>  extend <%= ext %>
 <% end %>

--- a/priv/templates/message.ex.eex
+++ b/priv/templates/message.ex.eex
@@ -1,6 +1,6 @@
 defmodule <%= name %> do
   @moduledoc false
-  use <%= using_module %> <%= options %>
+  use <%= using_module %><%= options %>
 
   <%= typespec %>
   defstruct [<%= struct_fields %>]

--- a/priv/templates/message.ex.eex
+++ b/priv/templates/message.ex.eex
@@ -1,6 +1,6 @@
 defmodule <%= name %> do
   @moduledoc false
-  use Protobuf<%= options %>
+  use <%= using_module %> <%= options %>
 
   <%= typespec %>
   defstruct [<%= struct_fields %>]


### PR DESCRIPTION
Adds the parameter using_module so that one can switch out the using macro and take over code generation. 💪 

Example:
myproto.proto

```
syntax = "proto3";

package my.proto.bar;

message Foo{
  string field1 = 1;
}
```

protoc --elixir_out=./lib --plugin=./protoc-gen-elixir --elixir_opt=using_module=MyMod.MyProtobuf myproto.proto

```elixir
defmodule My.Proto.Bar.Foo do
  @moduledoc false
  use MyMod.MyProtobuf, syntax: :proto3

  @type t :: %__MODULE__{
          field1: String.t()
        }
  defstruct [:field1]

  field :field1, 1, type: :string
end
```