### PR TITLE
Properly encode empty values for fields w/ extype extension

### DIFF
--- a/lib/protobuf/encoder.ex
+++ b/lib/protobuf/encoder.ex
@@ -87,6 +87,9 @@ defmodule Protobuf.Encoder do
 
   @doc false
   def skip_field?(syntax, val, prop)
+  def skip_field?(_syntax, val, %{type: type, options: options}) when not is_nil(options) do
+    FieldOptionsProcessor.skip?(type, val, options)
+  end
   def skip_field?(_, [], _), do: true
   def skip_field?(_, v, _) when map_size(v) == 0, do: true
   def skip_field?(:proto2, nil, %{optional?: true}), do: true

--- a/lib/protobuf/extype/extype_protocol.ex
+++ b/lib/protobuf/extype/extype_protocol.ex
@@ -60,6 +60,7 @@ defmodule Extype do
     end
   end
 
+  def skip?(_type, nil, _extype), do: true
   def skip?(_type, _value, _extype), do: false
 
   @spec type_default(type, extype) :: any

--- a/test/protobuf/protoc/integration_test.exs
+++ b/test/protobuf/protoc/integration_test.exs
@@ -92,4 +92,22 @@ defmodule Protobuf.Protoc.IntegrationTest do
 
     assert msg |> Ext.MyMessage.encode() |> Ext.MyMessage.decode() == msg
   end
+
+  test "extension use case empty values" do
+    msg =
+      Ext.MyMessage.new(
+        f1: 0.0,
+        f3: 0,
+        f7: false,
+        f8: "",
+        nested: Ext.Nested.new(),
+        no_extype: %Google.Protobuf.StringValue{value: ""},
+        normal1: 0,
+        normal2: "",
+        # FIX: should be []
+        repeated_field: nil
+      )
+
+    assert msg |> Ext.MyMessage.encode() |> Ext.MyMessage.decode() == msg
+  end
 end

--- a/test/protobuf/protoc/proto_gen/extension2.pb.ex
+++ b/test/protobuf/protoc/proto_gen/extension2.pb.ex
@@ -86,18 +86,34 @@ defmodule Ext.MyMessage do
   field :f7, 7, type: Google.Protobuf.BoolValue, options: [extype: "boolean"]
   field :f8, 8, type: Google.Protobuf.StringValue, options: [extype: "String.t"]
   field :f9, 9, type: Google.Protobuf.BytesValue, options: [extype: "String.t()"]
-  field :no_extype, 10, type: Google.Protobuf.StringValue
+  field :no_extype, 10, type: Google.Protobuf.StringValue, json_name: "noExtype"
 
   field :repeated_field, 11,
     repeated: true,
     type: Google.Protobuf.StringValue,
+    json_name: "repeatedField",
     options: [extype: "String.t"]
 
   field :normal1, 12, type: :uint64
   field :normal2, 13, type: :string
   field :nested, 14, type: Ext.Nested
   field :color, 15, type: Ext.TrafficLightColor, enum: true
-  field :color_lc, 16, type: Ext.TrafficLightColor, enum: true, options: [enum: "lowercase"]
-  field :color_depr, 17, type: Ext.TrafficLightColor, enum: true, options: [enum: "deprefix"]
-  field :color_atom, 18, type: Ext.TrafficLightColor, enum: true, options: [enum: "atomize"]
+
+  field :color_lc, 16,
+    type: Ext.TrafficLightColor,
+    enum: true,
+    json_name: "colorLc",
+    options: [enum: "lowercase"]
+
+  field :color_depr, 17,
+    type: Ext.TrafficLightColor,
+    enum: true,
+    json_name: "colorDepr",
+    options: [enum: "deprefix"]
+
+  field :color_atom, 18,
+    type: Ext.TrafficLightColor,
+    enum: true,
+    json_name: "colorAtom",
+    options: [enum: "atomize"]
 end


### PR DESCRIPTION
Behaviour on brex-head: 
![image](https://user-images.githubusercontent.com/33362730/87350833-4c165480-c50d-11ea-8420-1a0742848762.png)
Empty values turned to nil after decoding. 