### PR TITLE
Fix: oneof enums w/ default value decodes to nil when field extensions present

### DIFF
--- a/lib/protobuf/extype/enum_transform.ex
+++ b/lib/protobuf/extype/enum_transform.ex
@@ -59,8 +59,6 @@ defmodule EnumTransform do
     value
   end
 
-  def skip?(_type, nil, _transform), do: true
-
   def skip?(type, v, transform) do
     mods = validate_and_get_transformers!(type, transform)
     v = transform_atom(type, v, mods, :forward)

--- a/lib/protobuf/extype/extype_protocol.ex
+++ b/lib/protobuf/extype/extype_protocol.ex
@@ -62,7 +62,6 @@ defmodule Extype do
   end
 
   @spec skip?(type, value, extype) :: boolean
-  def skip?(_type, nil, _extype), do: true
   def skip?(_type, _value, _extype), do: false
 
   @spec type_default(type, extype) :: any

--- a/lib/protobuf/field_options_processor.ex
+++ b/lib/protobuf/field_options_processor.ex
@@ -58,8 +58,9 @@ defmodule Protobuf.FieldOptionsProcessor do
   end
 
   def skip?(type, value, _prop, []), do: Protobuf.Encoder.is_enum_default?(type, value)
-
+  def skip?(_type, nil, _prop, _options), do: true
   def skip?(_type, _value, %{repeated?: true}, _options), do: false
+  def skip?(_type, _value, %{oneof: oneof}, _options) when not is_nil(oneof), do: false
 
   def skip?(type, value, _prop, options) do
     {mod, option} = get_mod(options)

--- a/test/protobuf/protoc/integration_test.exs
+++ b/test/protobuf/protoc/integration_test.exs
@@ -125,14 +125,21 @@ defmodule Protobuf.Protoc.IntegrationTest do
         color: nil,
         color_lc: nil,
         color_depr: nil,
-        color_atom: nil
+        color_atom: nil,
+        enums_oneof: {:color_oneof_atom, :invalid}
       )
 
     assert %Ext.MyMessage{
              color: :TRAFFIC_LIGHT_COLOR_INVALID,
              color_atom: :invalid,
              color_depr: :INVALID,
-             color_lc: :traffic_light_color_invalid
+             color_lc: :traffic_light_color_invalid,
+             enums_oneof: {:color_oneof_atom, :invalid}
            } = msg |> Ext.MyMessage.encode() |> Ext.MyMessage.decode()
+  end
+
+  test "empty message" do
+    assert Ext.MyMessage.new() |> Ext.MyMessage.encode() |> Ext.MyMessage.decode() ==
+             Ext.MyMessage.new()
   end
 end

--- a/test/protobuf/protoc/proto/extension2.proto
+++ b/test/protobuf/protoc/proto/extension2.proto
@@ -48,4 +48,8 @@ message MyMessage {
   repeated TrafficLightColor color_repeated = 19 [(brex.elixirpb.field).enum="atomize"];
   repeated TrafficLightColor color_repeated_normal = 20;
   repeated string normal3 = 21;
+  oneof enums_oneof {
+    TrafficLightColor color_oneof = 22;
+    TrafficLightColor color_oneof_atom = 23 [(brex.elixirpb.field).enum="atomize"];
+  }
 }

--- a/test/protobuf/protoc/proto_gen/extension2.pb.ex
+++ b/test/protobuf/protoc/proto_gen/extension2.pb.ex
@@ -37,6 +37,7 @@ defmodule Ext.MyMessage do
   use Protobuf, custom_field_options?: true, syntax: :proto3
 
   @type t :: %__MODULE__{
+          enums_oneof: {atom, any},
           f1: float | nil,
           f2: float | nil,
           f3: integer | nil,
@@ -60,6 +61,7 @@ defmodule Ext.MyMessage do
           normal3: [String.t()]
         }
   defstruct [
+    :enums_oneof,
     :f1,
     :f2,
     :f3,
@@ -82,6 +84,8 @@ defmodule Ext.MyMessage do
     :color_repeated_normal,
     :normal3
   ]
+
+  oneof :enums_oneof, 0
 
   field :f1, 1, type: Google.Protobuf.DoubleValue, options: [extype: "float"]
   field :f2, 2, type: Google.Protobuf.FloatValue, options: [extype: "float"]
@@ -137,4 +141,17 @@ defmodule Ext.MyMessage do
     json_name: "colorRepeatedNormal"
 
   field :normal3, 21, repeated: true, type: :string
+
+  field :color_oneof, 22,
+    type: Ext.TrafficLightColor,
+    enum: true,
+    json_name: "colorOneof",
+    oneof: 0
+
+  field :color_oneof_atom, 23,
+    type: Ext.TrafficLightColor,
+    enum: true,
+    json_name: "colorOneofAtom",
+    oneof: 0,
+    options: [enum: "atomize"]
 end


### PR DESCRIPTION
Fixes the bug below. Only happens when enum value is the 0th variant (the default). 

previously 
```
      Ext.MyMessage.new(enums_oneof: {:color_oneof_atom, :invalid}) 
      |> Ext.MyMessage.encode() 
      |> Ext.MyMessage.decode()

>>>  %Ext.MyMessage{enums_oneof: nil}
```