### PR TITLE
Add new_and_verify!/1

### DIFF
--- a/lib/protobuf.ex
+++ b/lib/protobuf.ex
@@ -54,6 +54,15 @@ defmodule Protobuf do
         Protobuf.Builder.new!(__MODULE__, attrs)
       end
 
+      def new_and_verify!(attrs) do
+        struct = Protobuf.Builder.new!(__MODULE__, attrs)
+
+        # Will raise if unable to encode.
+        Protobuf.Encoder.encode(struct)
+
+        struct
+      end
+
       unquote(def_encode_decode())
     end
   end
@@ -81,6 +90,13 @@ defmodule Protobuf do
   errors will be raised if unknown keys are passed.
   """
   @callback new!(Enum.t()) :: struct
+
+  @doc """
+  Similar to `new!/1`, but also verifies that the struct can be encoded.
+  Will raise if built struct cannot be encoded. Struct returned is guaranteed to be
+  able to be encoded.
+  """
+  @callback new_and_verify!(Enum.t()) :: struct
 
   @doc """
   Encode the struct to a protobuf binary.

--- a/test/protobuf/builder_test.exs
+++ b/test/protobuf/builder_test.exs
@@ -97,4 +97,22 @@ defmodule Protobuf.BuilderTest do
     assert %TestMsg.Ext.DualNonUse{b: %{__struct__: "hello"}} ==
              TestMsg.Ext.DualNonUse.new(b: %{__struct__: "hello"})
   end
+
+  test "new_and_verify!/1 builds struct" do
+    result = Foo.Bar.new_and_verify!(a: 20, b: "test")
+    assert result.a == 20
+    assert result.b == "test"
+  end
+
+  test "new_and_verify!/1 raises on invalid data type" do
+    assert_raise Protobuf.EncodeError, fn ->
+      Foo.Bar.new_and_verify!(a: "invalid type", b: "test")
+    end
+  end
+
+  test "new_and_verify!/1 raises on invalid enum value" do
+    assert_raise Protobuf.EncodeError, fn ->
+      Foo.new_and_verify!(j: :invalid_value)
+    end
+  end
 end


### PR DESCRIPTION
A problem that we've been plagued by again and again is not finding out that a Protobuf is being constructed with incorrect values until it's run in production. Right now there's no way to verify this in unit tests unless you manually call `encode` on every single Protobuf struct that's instantiated. That's way too cumbersome to be effective!

What I added here is a method called `new_and_verify!` which constructs a struct and also verifies that it's able to be encoded. If not, it raises.

The world I envision is one in which we use `new_and_verify!` whenever we instantiate a Protobuf struct so that anytime we run our unit tests we know for a fact that they'll be able to encoded in production.



I'm in no way at all attached to calling this `new_and_verify!` - absolutely open to other names. In my opinion this is really what `new!` should do, but I don't want to make a breaking change.