### PR TITLE
[SYS-800] Add Verifier module and new_and_verify! method

### DIFF
--- a/lib/protobuf.ex
+++ b/lib/protobuf.ex
@@ -54,14 +54,24 @@ defmodule Protobuf do
         Protobuf.Builder.new!(__MODULE__, attrs)
       end
 
+      @doc """
+      `new_and_verify!` makes sure that the values used to instantiate a
+      protobuf struct have valid types. For example, if `a` is a string field
+      in `Foo`,
+
+          Foo.new_and_verify!(a: 123)
+
+      would raise an exception.
+      """
       def new_and_verify!(attrs) do
         struct = Protobuf.Builder.new!(__MODULE__, attrs)
 
         case Protobuf.Verifier.verify(struct) do
-          {:error, message} ->
-            raise Protobuf.VerificationError, message: message
+          {:error, messages} ->
+            raise Protobuf.VerificationError, message: Enum.join(messages, "\n\t")
 
-          :ok -> struct
+          :ok ->
+            struct
         end
       end
 

--- a/lib/protobuf.ex
+++ b/lib/protobuf.ex
@@ -54,6 +54,21 @@ defmodule Protobuf do
         Protobuf.Builder.new!(__MODULE__, attrs)
       end
 
+      def new_and_verify!(attrs) do
+        struct = Protobuf.Builder.new!(__MODULE__, attrs)
+
+        case Protobuf.Verifier.verify(struct) do
+          {:error, message} ->
+            raise Protobuf.VerificationError, message: message
+
+          :ok ->
+            # Do nothing
+            nil
+        end
+
+        struct
+      end
+
       unquote(def_encode_decode())
     end
   end

--- a/lib/protobuf.ex
+++ b/lib/protobuf.ex
@@ -61,12 +61,8 @@ defmodule Protobuf do
           {:error, message} ->
             raise Protobuf.VerificationError, message: message
 
-          :ok ->
-            # Do nothing
-            nil
+          :ok -> struct
         end
-
-        struct
       end
 
       unquote(def_encode_decode())

--- a/lib/protobuf/error.ex
+++ b/lib/protobuf/error.ex
@@ -14,6 +14,10 @@ defmodule Protobuf.InvalidError do
   defexception [:message]
 end
 
+defmodule Protobuf.VerificationError do
+  defexception [:message]
+end
+
 defmodule Protobuf.ExtensionNotFound do
   defexception message: "extension for the field is not found"
 end

--- a/lib/protobuf/extype/enum_transform.ex
+++ b/lib/protobuf/extype/enum_transform.ex
@@ -65,6 +65,8 @@ defmodule EnumTransform do
     Protobuf.Encoder.is_enum_default?(type, v)
   end
 
+  def skip_verify?(_type, _v, _transform), do: false
+
   @spec encode_type(type, value, transform) :: binary
   def encode_type(type, v, transform) do
     mods = validate_and_get_transformers!(type, transform)
@@ -78,6 +80,13 @@ defmodule EnumTransform do
     # Pass decode_type_m a false key. Should be field name
     val = Protobuf.Decoder.decode_type_m(type, :enum, val)
     transform_atom(type, val, mods, :backward)
+  end
+
+  @spec verify_type(type, value, transform) :: :ok | {:error, String.t()}
+  def verify_type(type, v, transform) do
+    mods = validate_and_get_transformers!(type, transform)
+    v = transform_atom(type, v, mods, :forward)
+    Protobuf.Verifier.verify_type(type, v)
   end
 
   defp transform_atom(type, atom, mods, direction) do

--- a/lib/protobuf/extype/extype_protocol.ex
+++ b/lib/protobuf/extype/extype_protocol.ex
@@ -31,6 +31,9 @@ defprotocol Extype.Protocol do
 
   @spec decode_type(type, val :: binary, extype) :: value
   def decode_type(type, val, extype)
+
+  @spec verify_type(type, val :: binary, extype) :: :ok | {:error, String.t()}
+  def verify_type(type, val, extype)
 end
 
 defmodule Extype do
@@ -64,6 +67,9 @@ defmodule Extype do
   @spec skip?(type, value, extype) :: boolean
   def skip?(_type, _value, _extype), do: false
 
+  @spec skip_verify?(type, value, extype) :: boolean
+  def skip_verify?(_type, _value, _extype), do: false
+
   @spec type_default(type, extype) :: any
   def type_default(type, extype) do
     mod = get_mod(type)
@@ -94,6 +100,14 @@ defmodule Extype do
     extype = pad_parens(extype)
     atom_extype = mod.validate_and_to_atom_extype!(type, extype)
     mod.decode_type(type, val, atom_extype)
+  end
+
+  @spec verify_type(val :: binary, type, extype) :: :ok | {:error, String.t()}
+  def verify_type(type, v, extype) do
+    mod = get_mod(type)
+    extype = pad_parens(extype)
+    atom_extype = mod.validate_and_to_atom_extype!(type, extype)
+    mod.verify_type(type, v, atom_extype)
   end
 
   defp pad_parens(extype) do

--- a/lib/protobuf/extype/timestamp.ex
+++ b/lib/protobuf/extype/timestamp.ex
@@ -42,5 +42,8 @@ defimpl Extype.Protocol, for: Google.Protobuf.Timestamp do
     if extype == :naivedatetime, do: DateTime.to_naive(value), else: value
   end
 
-  def verify_type(_type, _val, _extype), do: :ok
+  def verify_type(_type, %DateTime{} = _val, :datetime), do: :ok
+  def verify_type(_type, %NaiveDateTime{} = _val, :naivedatetime), do: :ok
+  def verify_type(_type, _val, :datetime), do: {:error, "non-DateTime value for a timestamp field with extype DateTime.t()"}
+  def verify_type(_type, _val, :naivedatetime), do: {:error, "non-NaiveDateTime value for a timestamp field with extype NaiveDateTime.t()"}
 end

--- a/lib/protobuf/extype/timestamp.ex
+++ b/lib/protobuf/extype/timestamp.ex
@@ -44,6 +44,10 @@ defimpl Extype.Protocol, for: Google.Protobuf.Timestamp do
 
   def verify_type(_type, %DateTime{} = _val, :datetime), do: :ok
   def verify_type(_type, %NaiveDateTime{} = _val, :naivedatetime), do: :ok
-  def verify_type(_type, _val, :datetime), do: {:error, "non-DateTime value for a timestamp field with extype DateTime.t()"}
-  def verify_type(_type, _val, :naivedatetime), do: {:error, "non-NaiveDateTime value for a timestamp field with extype NaiveDateTime.t()"}
+
+  def verify_type(_type, _val, :datetime),
+    do: {:error, "non-DateTime value for a timestamp field with extype DateTime.t()"}
+
+  def verify_type(_type, _val, :naivedatetime),
+    do: {:error, "non-NaiveDateTime value for a timestamp field with extype NaiveDateTime.t()"}
 end

--- a/lib/protobuf/extype/timestamp.ex
+++ b/lib/protobuf/extype/timestamp.ex
@@ -41,4 +41,6 @@ defimpl Extype.Protocol, for: Google.Protobuf.Timestamp do
 
     if extype == :naivedatetime, do: DateTime.to_naive(value), else: value
   end
+
+  def verify_type(_type, _val, _extype), do: :ok
 end

--- a/lib/protobuf/extype/wrappers.ex
+++ b/lib/protobuf/extype/wrappers.ex
@@ -53,4 +53,8 @@ defimpl Extype.Protocol,
     [_tag, _wire, val | _rest] = Protobuf.Decoder.decode_raw(val)
     Protobuf.Decoder.decode_type_m(extype, :value, val)
   end
+
+  def verify_type(_type, v, extype) do
+    Protobuf.Verifier.verify_type(extype, v)
+  end
 end

--- a/lib/protobuf/field_options_processor.ex
+++ b/lib/protobuf/field_options_processor.ex
@@ -91,7 +91,7 @@ defmodule Protobuf.FieldOptionsProcessor do
     mod.decode_type(val, type, option)
   end
 
-  def verify_type(type, v, []), do: Protobuf.Verifier.verify(type, v, [])
+  def verify_type(type, v, []), do: Protobuf.Verifier.verify(type, v)
 
   def verify_type(type, v, options) do
     {mod, option} = get_mod(options)

--- a/lib/protobuf/field_options_processor.ex
+++ b/lib/protobuf/field_options_processor.ex
@@ -67,6 +67,16 @@ defmodule Protobuf.FieldOptionsProcessor do
     mod.skip?(type, value, option)
   end
 
+  def skip_verify?(_type, _value, _prop, []), do: false
+  def skip_verify?(_type, nil, _prop, _options), do: true
+  def skip_verify?(_type, _value, %{repeated?: true}, _options), do: false
+  def skip_verify?(_type, _value, %{oneof: oneof}, _options) when not is_nil(oneof), do: false
+
+  def skip_verify?(type, value, _prop, options) do
+    {mod, option} = get_mod(options)
+    mod.skip_verify?(type, value, option)
+  end
+
   def encode_type(type, v, []), do: Protobuf.Encoder.encode(type, v, [])
 
   def encode_type(type, v, options) do
@@ -79,5 +89,12 @@ defmodule Protobuf.FieldOptionsProcessor do
   def decode_type(val, type, options) do
     {mod, option} = get_mod(options)
     mod.decode_type(val, type, option)
+  end
+
+  def verify_type(type, v, []), do: Protobuf.Verifier.verify(type, v, [])
+
+  def verify_type(type, v, options) do
+    {mod, option} = get_mod(options)
+    mod.verify_type(type, v, option)
   end
 end

--- a/lib/protobuf/verifier.ex
+++ b/lib/protobuf/verifier.ex
@@ -69,7 +69,7 @@ defmodule Protobuf.Verifier do
 
   defp wrap_error({:error, msg}, struct, prop) do
     wrapped_msg =
-      "Got error when verifying the values of #{inspect(struct.__struct__)}##{prop.name_atom}: #{
+      "Got error when verifying the value(s) of #{inspect(struct.__struct__)}##{prop.name_atom}: #{
         msg
       }"
 
@@ -143,7 +143,7 @@ defmodule Protobuf.Verifier do
   defp class_field(%{wire_type: wire_delimited(), embedded?: true}), do: :embedded
   defp class_field(_), do: :normal
 
-  @spec verify_type(atom, any) :: :ok
+  @spec verify_type(atom, any) :: :ok | {:error, String.t()}
   def verify_type(:string, n) when is_binary(n), do: :ok
   def verify_type(:bool, true), do: :ok
   def verify_type(:bool, false), do: :ok

--- a/lib/protobuf/verifier.ex
+++ b/lib/protobuf/verifier.ex
@@ -81,7 +81,7 @@ defmodule Protobuf.Verifier do
 
   def skip_field?(_, [], _), do: true
   def skip_field?(_, v, _) when map_size(v) == 0, do: true
-  def skip_field?(:proto2, _, %{optional?: true}), do: true
+  def skip_field?(:proto2, nil, %{optional?: true}), do: true
   def skip_field?(:proto3, nil, _), do: true
   def skip_field?(_, _, _), do: false
 

--- a/lib/protobuf/verifier.ex
+++ b/lib/protobuf/verifier.ex
@@ -86,7 +86,7 @@ defmodule Protobuf.Verifier do
   def skip_field?(:proto3, nil, _), do: true
   def skip_field?(_, _, _), do: false
 
-  @spec verify_field(atom, any, FieldProps.t()) :: :ok | {:error, String.t()}
+  @spec verify_field(atom, any, FieldProps.t()) :: :ok | {:error, [String.t()]}
   defp verify_field(
          :normal,
          val,
@@ -132,7 +132,8 @@ defmodule Protobuf.Verifier do
          prop.name_atom
        }"}
 
-  defp repeated_or_not(val, true = _repeated, func), do: Enum.map(val, func)
+  defp repeated_or_not(val, true = _repeated, func) when is_list(val) or is_tuple(val) or is_map(val), do: Enum.map(val, func)
+  defp repeated_or_not(_val, true = _repeated, _func), do: [{:error, "Got value for repeated or map field that wasn't a list, tuple, or map"}]
   defp repeated_or_not(val, false = _repeated, func), do: [func.(val)]
 
   @spec ok_or_aggregate_errors([:ok | {:error, String.t()}]) :: :ok | {:error, [String.t()]}

--- a/lib/protobuf/verifier.ex
+++ b/lib/protobuf/verifier.ex
@@ -135,7 +135,7 @@ defmodule Protobuf.Verifier do
   defp repeated_or_not(val, true = _repeated, func), do: Enum.map(val, func)
   defp repeated_or_not(val, false = _repeated, func), do: [func.(val)]
 
-  @spec ok_or_aggregate_errors([:ok | {:error, String.t()}]) :: :ok :: {:error, [String.t()]}
+  @spec ok_or_aggregate_errors([:ok | {:error, String.t()}]) :: :ok | {:error, [String.t()]}
   defp ok_or_aggregate_errors([]), do: :ok
   defp ok_or_aggregate_errors([:ok | rest]), do: ok_or_aggregate_errors(rest)
 
@@ -194,7 +194,7 @@ defmodule Protobuf.Verifier do
     if type.mapping() |> Map.has_key?(n) do
       :ok
     else
-      {:error, "#{inspect(n)} is not a valid value in enum #{type}"}
+      {:error, "invalid value for enum #{type}"}
     end
   end
 
@@ -202,18 +202,18 @@ defmodule Protobuf.Verifier do
     if type.__reverse_mapping__() |> Map.has_key?(n) do
       :ok
     else
-      {:error, "#{inspect(n)} is not a valid value in enum #{type}"}
+      {:error, "invalid value for enum #{type}"}
     end
   end
 
   # Enum failure case
-  def verify_type({:enum, type}, n) do
-    {:error, "#{inspect(n)} is invalid for type #{type}"}
+  def verify_type({:enum, type}, _n) do
+    {:error, "invalid value for type #{type}"}
   end
 
   # General failure case
-  def verify_type(type, n) do
-    {:error, "#{inspect(n)} is invalid for type #{type}"}
+  def verify_type(type, _n) do
+    {:error, "invalid value for type #{type}"}
   end
 
   defp skip_enum?(%{type: type, options: options} = prop, value) when not is_nil(options) do

--- a/lib/protobuf/verifier.ex
+++ b/lib/protobuf/verifier.ex
@@ -1,0 +1,276 @@
+defmodule Protobuf.Verifier do
+  @moduledoc """
+  Checks whether the values passed into a Message.new() call are valid.
+
+  The structure of this code is based on Protobuf.Encoder
+  """
+
+  import Protobuf.WireTypes
+  alias Protobuf.{MessageProps, FieldProps, FieldOptionsProcessor}
+
+  @spec verify(atom, map | struct, keyword) :: :ok | {:error, String.t()}
+  def verify(mod, msg, opts) do
+    case msg do
+      %{__struct__: ^mod} ->
+        verify(msg, opts)
+
+      _ ->
+        verify(mod.new(msg), opts)
+    end
+  end
+
+  @spec verify(struct, keyword) :: :ok | {:error, String.t()}
+  def verify(%mod{} = struct, _opts \\ []) do
+    verify!(struct, mod.__message_props__())
+  end
+
+  @spec verify!(struct, MessageProps.t()) :: :ok | {:error, String.t()}
+  def verify!(struct, %{field_props: field_props} = props) do
+    syntax = props.syntax
+
+    with {:ok, oneofs} <- oneof_actual_vals(props, struct),
+         :ok <- verify_fields(Map.values(field_props), syntax, struct, oneofs, :ok) do
+      if syntax == :proto2 do
+        verify_extensions(struct)
+      else
+        :ok
+      end
+    else
+      :ok -> :ok
+      {:error, err} -> {:error, err}
+    end
+  end
+
+  defp verify_fields([], _, _, _, :ok), do: :ok
+
+  defp verify_fields([prop | tail], syntax, struct, oneofs, :ok) do
+    %{name_atom: name, oneof: oneof} = prop
+
+    val =
+      if oneof do
+        oneofs[name]
+      else
+        case struct do
+          %{^name => v} -> v
+          _ -> nil
+        end
+      end
+
+    if skip_field?(syntax, val, prop) || skip_enum?(prop, val) do
+      verify_fields(tail, syntax, struct, oneofs, :ok)
+      |> wrap_error(struct, prop)
+    else
+      prev_result = verify_field(class_field(prop), val, prop)
+
+      verify_fields(tail, syntax, struct, oneofs, prev_result)
+      |> wrap_error(struct, prop)
+    end
+  end
+
+  defp verify_fields(_, _, _, _, prev_error), do: prev_error
+
+  defp wrap_error({:error, msg}, struct, prop) do
+    wrapped_msg =
+      "Got error when verifying the values of #{inspect(struct.__struct__)}##{prop.name_atom}: #{
+        msg
+      }"
+
+    {:error, wrapped_msg}
+  end
+
+  defp wrap_error(:ok, _struct, _prop), do: :ok
+
+  @doc false
+  def skip_field?(syntax, val, prop)
+
+  def skip_field?(_syntax, val, %{type: type, options: options} = prop) when not is_nil(options),
+    do: FieldOptionsProcessor.skip_verify?(type, val, prop, options)
+
+  def skip_field?(_, [], _), do: true
+  def skip_field?(_, v, _) when map_size(v) == 0, do: true
+  def skip_field?(:proto2, _, %{optional?: true}), do: true
+  def skip_field?(:proto3, nil, _), do: true
+  def skip_field?(_, _, _), do: false
+
+  @spec verify_field(atom, any, FieldProps.t()) :: :ok
+  defp verify_field(
+         :normal,
+         val,
+         %{encoded_fnum: _fnum, type: type, repeated?: is_repeated} = prop
+       ) do
+    repeated_or_not(val, is_repeated, fn v ->
+      if is_nil(prop.options) do
+        verify_type(type, v)
+      else
+        FieldOptionsProcessor.verify_type(type, v, prop.options)
+      end
+    end)
+    |> first_non_ok_value_if_present()
+  end
+
+  defp verify_field(
+         :embedded,
+         val,
+         %{encoded_fnum: _fnum, repeated?: is_repeated, map?: is_map, type: type} = prop
+       ) do
+    repeated = is_repeated || is_map
+
+    repeated_or_not(val, repeated, fn v ->
+      v = if is_map, do: struct(prop.type, %{key: elem(v, 0), value: elem(v, 1)}), else: v
+
+      if is_nil(prop.options) do
+        verify(type, v, iolist: true)
+      else
+        FieldOptionsProcessor.verify_type(type, v, prop.options)
+      end
+    end)
+    |> first_non_ok_value_if_present()
+  rescue
+    # This is kind of a dirty way to handle cases where repeated == true but val isn't something you can iterate over
+    Protocol.UndefinedError ->
+      {:error,
+       "Got a value: #{inspect(val)} that isn't a map or list for the repeated or map field #{
+         prop.name_atom
+       }"}
+  end
+
+  defp repeated_or_not(val, repeated, func) do
+    if repeated do
+      Enum.map(val, func)
+    else
+      [func.(val)]
+    end
+  end
+
+  defp first_non_ok_value_if_present([]), do: :ok
+  defp first_non_ok_value_if_present([:ok | rest]), do: first_non_ok_value_if_present(rest)
+  defp first_non_ok_value_if_present([non_ok_value | _rest]), do: non_ok_value
+
+  @spec class_field(map) :: atom
+  defp class_field(%{wire_type: wire_delimited(), embedded?: true}), do: :embedded
+  defp class_field(_), do: :normal
+
+  @doc false
+  @spec verify_type(atom, any) :: :ok
+  def verify_type(:int32, n) when is_integer(n) and n >= -0x80000000 and n <= 0x7FFFFFFF, do: :ok
+
+  def verify_type(:int64, n)
+      when is_integer(n) and n >= -0x8000000000000000 and n <= 0x7FFFFFFFFFFFFFFF,
+      do: :ok
+
+  def verify_type(:uint32, n) when is_integer(n) and n >= 0 and n <= 0xFFFFFFFF, do: :ok
+  def verify_type(:uint64, n) when is_integer(n) and n >= 0 and n <= 0xFFFFFFFFFFFFFFFF, do: :ok
+  def verify_type(:string, n) when is_binary(n), do: :ok
+  def verify_type(:bool, true), do: :ok
+  def verify_type(:bool, false), do: :ok
+
+  def verify_type({:enum, type}, n) when is_atom(n) do
+    if type.mapping() |> Map.has_key?(n) do
+      :ok
+    else
+      {:error, "#{inspect(n)} is not a valid value in enum #{type}"}
+    end
+  end
+
+  def verify_type({:enum, type}, n) when is_integer(n) do
+    if type.__reverse_mapping__() |> Map.has_key?(n) do
+      :ok
+    else
+      {:error, "#{inspect(n)} is not a valid value in enum #{type}"}
+    end
+  end
+
+  def verify_type(:float, :infinity), do: :ok
+  def verify_type(:float, :negative_infinity), do: :ok
+  def verify_type(:float, :nan), do: :ok
+  def verify_type(:float, n) when is_number(n), do: :ok
+  def verify_type(:double, :infinity), do: :ok
+  def verify_type(:double, :negative_infinity), do: :ok
+  def verify_type(:double, :nan), do: :ok
+  def verify_type(:double, n) when is_number(n), do: :ok
+  def verify_type(:bytes, n) when is_binary(n), do: :ok
+  def verify_type(:sint32, n) when is_integer(n) and n >= -0x80000000 and n <= 0x7FFFFFFF, do: :ok
+
+  def verify_type(:sint64, n)
+      when is_integer(n) and n >= -0x8000000000000000 and n <= 0x7FFFFFFFFFFFFFFF,
+      do: :ok
+
+  def verify_type(:fixed64, n) when is_integer(n) and n >= 0 and n <= 0xFFFFFFFFFFFFFFFF, do: :ok
+
+  def verify_type(:sfixed64, n)
+      when is_integer(n) and n >= -0x8000000000000000 and n <= 0x7FFFFFFFFFFFFFFF,
+      do: :ok
+
+  def verify_type(:fixed32, n) when is_integer(n) and n >= 0 and n <= 0xFFFFFFFF, do: :ok
+
+  def verify_type(:sfixed32, n) when is_integer(n) and n >= -0x80000000 and n <= 0x7FFFFFFF,
+    do: :ok
+
+  # Failure cases
+  def verify_type({:enum, type}, n) do
+    {:error, "#{inspect(n)} is invalid for type #{type}"}
+  end
+
+  def verify_type(type, n) do
+    {:error, "#{inspect(n)} is invalid for type #{type}"}
+  end
+
+  defp skip_enum?(%{type: type, options: options} = prop, value) when not is_nil(options) do
+    FieldOptionsProcessor.skip_verify?(type, value, prop, options)
+  end
+
+  defp skip_enum?(%{type: _type}, nil), do: true
+  defp skip_enum?(%{type: _type}, _value), do: false
+
+  defmodule(OneofActualValsError, do: defexception([:message]))
+
+  # I don't like this control flow, but it works
+  defp oneof_actual_vals(
+         %{field_tags: field_tags, field_props: field_props, oneof: oneof},
+         struct
+       ) do
+    result =
+      Enum.reduce(oneof, %{}, fn {field, index}, acc ->
+        case Map.get(struct, field, nil) do
+          {f, val} ->
+            %{oneof: oneof} = field_props[field_tags[f]]
+
+            if oneof != index do
+              raise OneofActualValsError,
+                message: ":#{f} doesn't belong to #{inspect(struct.__struct__)}##{field}"
+            else
+              Map.put(acc, f, val)
+            end
+
+          nil ->
+            acc
+
+          _ ->
+            raise OneofActualValsError,
+              message:
+                "#{inspect(struct.__struct__)}##{field} has the wrong structure: the value of an oneof field should be {key, val} or nil"
+        end
+      end)
+
+    {:ok, result}
+  rescue
+    e in OneofActualValsError -> {:error, e.message}
+  end
+
+  defp verify_extensions(%mod{__pb_extensions__: pb_exts}) when is_map(pb_exts) do
+    Enum.map(pb_exts, fn {{ext_mod, key}, val} ->
+      case Protobuf.Extension.get_extension_props(mod, ext_mod, key) do
+        %{field_props: prop} ->
+          if !skip_field?(:proto2, val, prop) || !skip_enum?(prop, val) do
+            verify_field(class_field(prop), val, prop)
+          end
+
+        _ ->
+          :ok
+      end
+    end)
+    |> first_non_ok_value_if_present()
+  end
+
+  defp verify_extensions(_), do: :ok
+end

--- a/lib/protobuf/verifier.ex
+++ b/lib/protobuf/verifier.ex
@@ -1,17 +1,18 @@
 defmodule Protobuf.Verifier do
   @moduledoc """
-  Checks whether the values passed into a Message.new() call are valid.
-
-  The structure of this code is based on Protobuf.Encoder
+  Checks whether the values used when instantiating a new protobuf struct are valid.
   """
 
   import Protobuf.WireTypes
   alias Protobuf.{MessageProps, FieldProps, FieldOptionsProcessor}
 
-  @spec verify(struct) :: :ok | {:error, String.t()}
+  @doc """
+  Returns `:ok` or a tuple `{:error, <list-of-issues>}`
+  """
+  @spec verify(struct) :: :ok | {:error, [String.t()]}
   def verify(%mod{} = struct), do: do_verify(struct, mod.__message_props__())
 
-  @spec verify(atom, struct | map) :: :ok | {:error, String.t()}
+  @spec verify(atom, struct | map) :: :ok | {:error, [String.t()]}
   def verify(mod, msg) do
     case msg do
       %{__struct__: ^mod} ->
@@ -19,14 +20,14 @@ defmodule Protobuf.Verifier do
 
       _ ->
         if is_map(msg) and Map.has_key?(msg, :__struct__) and mod != msg.__struct__ do
-          {:error, "got #{msg.__struct__} but expected #{mod}"}
+          {:error, ["got #{msg.__struct__} but expected #{mod}"]}
         else
           verify(mod.new!(msg))
         end
     end
   end
 
-  @spec do_verify(struct, MessageProps.t()) :: :ok | {:error, String.t()}
+  @spec do_verify(struct, MessageProps.t()) :: :ok | {:error, [String.t()]}
   defp do_verify(struct, %{field_props: field_props} = props) do
     syntax = props.syntax
 
@@ -39,7 +40,7 @@ defmodule Protobuf.Verifier do
       end
     else
       :ok -> :ok
-      {:error, message} -> {:error, message}
+      {:error, messages} -> {:error, messages}
     end
   end
 
@@ -62,14 +63,14 @@ defmodule Protobuf.Verifier do
         |> wrap_error(struct, prop)
       end
     end)
-    |> first_non_ok_value_if_present()
+    |> ok_or_aggregate_errors()
   end
 
   defp wrap_error(:ok, _struct, _prop), do: :ok
 
   defp wrap_error({:error, msg}, struct, prop) do
     wrapped_msg =
-      "Got error when verifying the value(s) of #{inspect(struct.__struct__)}##{prop.name_atom}: #{
+      "Error when verifying the value(s) of #{inspect(struct.__struct__)}##{prop.name_atom}: #{
         msg
       }"
 
@@ -98,7 +99,7 @@ defmodule Protobuf.Verifier do
         FieldOptionsProcessor.verify_type(type, v, prop.options)
       end
     end)
-    |> first_non_ok_value_if_present()
+    |> ok_or_aggregate_errors()
   end
 
   # The guard ensures that val's type matches the is_repeated or is_map parameters
@@ -120,7 +121,7 @@ defmodule Protobuf.Verifier do
         FieldOptionsProcessor.verify_type(type, v, prop.options)
       end
     end)
-    |> first_non_ok_value_if_present()
+    |> ok_or_aggregate_errors()
   end
 
   # A catchall for params that don't match the verify_field(:embedded) guard above
@@ -134,10 +135,18 @@ defmodule Protobuf.Verifier do
   defp repeated_or_not(val, true = _repeated, func), do: Enum.map(val, func)
   defp repeated_or_not(val, false = _repeated, func), do: [func.(val)]
 
-  # NOTE: This can aggregate all of the errors if we want
-  defp first_non_ok_value_if_present([]), do: :ok
-  defp first_non_ok_value_if_present([:ok | rest]), do: first_non_ok_value_if_present(rest)
-  defp first_non_ok_value_if_present([non_ok_value | _rest]), do: non_ok_value
+  @spec ok_or_aggregate_errors([:ok | {:error, String.t()}]) :: :ok :: {:error, [String.t()]}
+  defp ok_or_aggregate_errors([]), do: :ok
+  defp ok_or_aggregate_errors([:ok | rest]), do: ok_or_aggregate_errors(rest)
+
+  defp ok_or_aggregate_errors([{:error, message} | rest]),
+    do: ok_or_aggregate_errors(rest, [message])
+
+  defp ok_or_aggregate_errors([], messages), do: {:error, messages}
+  defp ok_or_aggregate_errors([:ok | rest], messages), do: ok_or_aggregate_errors(rest, messages)
+
+  defp ok_or_aggregate_errors([{:error, message} | rest], messages),
+    do: ok_or_aggregate_errors(rest, messages ++ [message])
 
   @spec class_field(map) :: atom
   defp class_field(%{wire_type: wire_delimited(), embedded?: true}), do: :embedded
@@ -225,7 +234,8 @@ defmodule Protobuf.Verifier do
             %{oneof: oneof} = field_props[field_tags[f]]
 
             if oneof != index do
-              {:halt, {:error, ":#{f} doesn't belong to #{inspect(struct.__struct__)}##{field}"}}
+              {:halt,
+               {:error, [":#{f} doesn't belong to #{inspect(struct.__struct__)}##{field}"]}}
             else
               {:cont, Map.put(acc, f, val)}
             end
@@ -236,7 +246,9 @@ defmodule Protobuf.Verifier do
           _ ->
             {:halt,
              {:error,
-              "#{inspect(struct.__struct__)}##{field} has the wrong structure: the value of a oneof field should be nil or {key, val} where key = atom of a field name inside the oneof and val = its value"}}
+              [
+                "#{inspect(struct.__struct__)}##{field} has the wrong structure: the value of a oneof field should be nil or {key, val} where key = atom of a field name inside the oneof and val = its value"
+              ]}}
         end
       end)
 
@@ -258,7 +270,7 @@ defmodule Protobuf.Verifier do
           :ok
       end
     end)
-    |> first_non_ok_value_if_present()
+    |> ok_or_aggregate_errors()
   end
 
   defp verify_extensions(_), do: :ok

--- a/test/protobuf/protoc/integration_test.exs
+++ b/test/protobuf/protoc/integration_test.exs
@@ -142,4 +142,34 @@ defmodule Protobuf.Protoc.IntegrationTest do
     assert Ext.MyMessage.new() |> Ext.MyMessage.encode() |> Ext.MyMessage.decode() ==
              Ext.MyMessage.new()
   end
+
+  test "new_and_verify!" do
+    dt = DateTime.from_unix!(1_464_096_368, :microsecond)
+
+    msg =
+      Ext.MyMessage.new_and_verify!(
+        f1: 1.0,
+        f2: 2.0,
+        f3: 3,
+        f4: 4,
+        f5: 5,
+        f6: 6,
+        f7: true,
+        f8: "8",
+        f9: "9",
+        nested: Ext.Nested.new(my_timestamp: {:dt, dt}),
+        no_extype: %Google.Protobuf.StringValue{value: "none"},
+        normal1: 1234,
+        normal2: "hello",
+        repeated_field: ["r1", "r2"],
+        color: :TRAFFIC_LIGHT_COLOR_UNSET,
+        color_lc: :traffic_light_color_invalid,
+        color_depr: :GREEN,
+        color_atom: :red,
+        color_repeated: [:red, :green],
+        color_repeated_normal: [:TRAFFIC_LIGHT_COLOR_RED, :TRAFFIC_LIGHT_COLOR_GREEN]
+      )
+
+    assert msg |> Ext.MyMessage.encode() |> Ext.MyMessage.decode() == msg
+  end
 end

--- a/test/protobuf/verifier_test.exs
+++ b/test/protobuf/verifier_test.exs
@@ -3,21 +3,25 @@ defmodule Protobuf.VerifierTest do
 
   alias Protobuf.Verifier
 
+  def has_single_message_matching(errs, target_msg) when is_list(errs) do
+    length(errs) == 1 and Enum.at(errs, 0) =~ target_msg
+  end
+
   test "verifies int32s" do
     assert :ok == Verifier.verify(TestMsg.Foo.new(a: 42))
     assert :ok == Verifier.verify(TestMsg.Foo.new(a: nil))
     assert :ok == Verifier.verify(TestMsg.Foo.new(a: -42))
     assert :ok == Verifier.verify(TestMsg.Foo.new(a: 0))
-    assert {:error, err} = Verifier.verify(TestMsg.Foo.new(a: "candle"))
-    assert err =~ ~s("candle" is invalid for type int32)
-    assert {:error, err} = Verifier.verify(TestMsg.Foo.new(a: 111_111_111_111))
-    assert err =~ ~s(111111111111 is invalid for type int32)
-    assert {:error, err} = Verifier.verify(TestMsg.Foo.new(a: 3.14))
-    assert err =~ ~s(3.14 is invalid for type int32)
-    assert {:error, _err} = Verifier.verify(TestMsg.Foo.new(a: false))
-    assert {:error, _err} = Verifier.verify(TestMsg.Foo.new(a: :enum_value))
-    assert {:error, _err} = Verifier.verify(TestMsg.Foo.new(a: TestMsg.Foo))
-    assert {:error, _err} = Verifier.verify(TestMsg.Foo.new(a: TestMsg.Foo.new()))
+    assert {:error, errs} = Verifier.verify(TestMsg.Foo.new(a: "candle"))
+    assert has_single_message_matching(errs, ~s("candle" is invalid for type int32))
+    assert {:error, errs} = Verifier.verify(TestMsg.Foo.new(a: 111_111_111_111))
+    assert has_single_message_matching(errs, ~s(111111111111 is invalid for type int32))
+    assert {:error, errs} = Verifier.verify(TestMsg.Foo.new(a: 3.14))
+    assert has_single_message_matching(errs, ~s(3.14 is invalid for type int32))
+    assert {:error, _errs} = Verifier.verify(TestMsg.Foo.new(a: false))
+    assert {:error, _errs} = Verifier.verify(TestMsg.Foo.new(a: :enum_value))
+    assert {:error, _errs} = Verifier.verify(TestMsg.Foo.new(a: TestMsg.Foo))
+    assert {:error, _errs} = Verifier.verify(TestMsg.Foo.new(a: TestMsg.Foo.new()))
   end
 
   # TestMsg.Scalars has a bunch of fields with the same name as their types
@@ -27,34 +31,34 @@ defmodule Protobuf.VerifierTest do
     assert :ok == Verifier.verify(TestMsg.Scalars.new(int64: 0))
     assert :ok == Verifier.verify(TestMsg.Scalars.new(int64: 9_223_372_036_854_775_807))
     assert :ok == Verifier.verify(TestMsg.Scalars.new(int64: nil))
-    assert {:error, err} = Verifier.verify(TestMsg.Scalars.new(int64: :test))
-    assert err =~ ~s(:test is invalid for type int64)
-    assert {:error, _err} = Verifier.verify(TestMsg.Scalars.new(int64: "broom"))
-    assert {:error, _err} = Verifier.verify(TestMsg.Scalars.new(int64: TestMsg.Foo.Bar.new()))
-    assert {:error, _err} = Verifier.verify(TestMsg.Scalars.new(int64: ["chair"]))
-    assert {:error, _err} = Verifier.verify(TestMsg.Scalars.new(int64: {:pillow}))
+    assert {:error, errs} = Verifier.verify(TestMsg.Scalars.new(int64: :test))
+    assert has_single_message_matching(errs, ~s(:test is invalid for type int64))
+    assert {:error, _errs} = Verifier.verify(TestMsg.Scalars.new(int64: "broom"))
+    assert {:error, _errs} = Verifier.verify(TestMsg.Scalars.new(int64: TestMsg.Foo.Bar.new()))
+    assert {:error, _errs} = Verifier.verify(TestMsg.Scalars.new(int64: ["chair"]))
+    assert {:error, _errs} = Verifier.verify(TestMsg.Scalars.new(int64: {:pillow}))
   end
 
   test "verifies uint32s" do
     assert :ok == Verifier.verify(TestMsg.Scalars.new(uint32: 11))
     assert :ok == Verifier.verify(TestMsg.Scalars.new(uint32: 4_294_967_295))
     assert :ok == Verifier.verify(TestMsg.Scalars.new(uint32: 0))
-    assert {:error, err} = Verifier.verify(TestMsg.Scalars.new(uint32: -11))
-    assert err =~ ~s(-11 is invalid for type uint32)
-    assert {:error, err} = Verifier.verify(TestMsg.Scalars.new(uint32: 4_294_967_296))
-    assert err =~ ~s(4294967296 is invalid for type uint32)
-    assert {:error, _err} = Verifier.verify(TestMsg.Scalars.new(uint32: 0.5))
-    assert {:error, _err} = Verifier.verify(TestMsg.Scalars.new(uint32: "shoe"))
+    assert {:error, errs} = Verifier.verify(TestMsg.Scalars.new(uint32: -11))
+    assert has_single_message_matching(errs, ~s(-11 is invalid for type uint32))
+    assert {:error, errs} = Verifier.verify(TestMsg.Scalars.new(uint32: 4_294_967_296))
+    assert has_single_message_matching(errs, ~s(4294967296 is invalid for type uint32))
+    assert {:error, _errs} = Verifier.verify(TestMsg.Scalars.new(uint32: 0.5))
+    assert {:error, _errs} = Verifier.verify(TestMsg.Scalars.new(uint32: "shoe"))
   end
 
   test "verifies uint64s" do
     assert :ok == Verifier.verify(TestMsg.Scalars.new(uint64: 11))
-    assert {:error, err} = Verifier.verify(TestMsg.Scalars.new(uint64: -11))
-    assert err =~ ~s(-11 is invalid for type uint64)
-    assert {:error, err} = Verifier.verify(TestMsg.Scalars.new(uint64: 1.5))
-    assert err =~ ~s(1.5 is invalid for type uint64)
-    assert {:error, _err} = Verifier.verify(TestMsg.Scalars.new(uint64: :blah))
-    assert {:error, _err} = Verifier.verify(TestMsg.Scalars.new(uint64: "book"))
+    assert {:error, errs} = Verifier.verify(TestMsg.Scalars.new(uint64: -11))
+    assert has_single_message_matching(errs, ~s(-11 is invalid for type uint64))
+    assert {:error, errs} = Verifier.verify(TestMsg.Scalars.new(uint64: 1.5))
+    assert has_single_message_matching(errs, ~s(1.5 is invalid for type uint64))
+    assert {:error, _errs} = Verifier.verify(TestMsg.Scalars.new(uint64: :blah))
+    assert {:error, _errs} = Verifier.verify(TestMsg.Scalars.new(uint64: "book"))
   end
 
   test "verifies floats and doubles" do
@@ -68,10 +72,10 @@ defmodule Protobuf.VerifierTest do
     assert :ok == Verifier.verify(TestMsg.Scalars.new(double: :negative_infinity))
     assert :ok == Verifier.verify(TestMsg.Scalars.new(float: :nan))
     assert :ok == Verifier.verify(TestMsg.Scalars.new(double: :nan))
-    assert {:error, _err} = Verifier.verify(TestMsg.Scalars.new(float: "rug"))
-    assert {:error, _err} = Verifier.verify(TestMsg.Scalars.new(double: "table"))
-    assert {:error, _err} = Verifier.verify(TestMsg.Scalars.new(float: true))
-    assert {:error, _err} = Verifier.verify(TestMsg.Scalars.new(double: false))
+    assert {:error, _errs} = Verifier.verify(TestMsg.Scalars.new(float: "rug"))
+    assert {:error, _errs} = Verifier.verify(TestMsg.Scalars.new(double: "table"))
+    assert {:error, _errs} = Verifier.verify(TestMsg.Scalars.new(float: true))
+    assert {:error, _errs} = Verifier.verify(TestMsg.Scalars.new(double: false))
   end
 
   test "verifies other numeric types" do
@@ -81,45 +85,45 @@ defmodule Protobuf.VerifierTest do
     assert :ok == Verifier.verify(TestMsg.Scalars.new(sfixed32: 11))
     assert :ok == Verifier.verify(TestMsg.Scalars.new(fixed64: 11))
     assert :ok == Verifier.verify(TestMsg.Scalars.new(sfixed64: 11))
-    assert {:error, _err} = Verifier.verify(TestMsg.Scalars.new(fixed32: -11))
-    assert {:error, _err} = Verifier.verify(TestMsg.Scalars.new(fixed64: -11))
-    assert {:error, _err} = Verifier.verify(TestMsg.Scalars.new(sint32: 1.5))
-    assert {:error, _err} = Verifier.verify(TestMsg.Scalars.new(sint64: 1.5))
-    assert {:error, _err} = Verifier.verify(TestMsg.Scalars.new(fixed32: 1.5))
-    assert {:error, _err} = Verifier.verify(TestMsg.Scalars.new(fixed64: 1.5))
-    assert {:error, _err} = Verifier.verify(TestMsg.Scalars.new(fixed32: 111_111_111_111))
-    assert {:error, _err} = Verifier.verify(TestMsg.Scalars.new(sint32: 111_111_111_111))
-    assert {:error, _err} = Verifier.verify(TestMsg.Scalars.new(sint32: "jack"))
-    assert {:error, _err} = Verifier.verify(TestMsg.Scalars.new(sint64: :jill))
-    assert {:error, _err} = Verifier.verify(TestMsg.Scalars.new(fixed32: <<117, 112>>))
-    assert {:error, _err} = Verifier.verify(TestMsg.Scalars.new(fixed64: %{"the" => "hill"}))
+    assert {:error, _errs} = Verifier.verify(TestMsg.Scalars.new(fixed32: -11))
+    assert {:error, _errs} = Verifier.verify(TestMsg.Scalars.new(fixed64: -11))
+    assert {:error, _errs} = Verifier.verify(TestMsg.Scalars.new(sint32: 1.5))
+    assert {:error, _errs} = Verifier.verify(TestMsg.Scalars.new(sint64: 1.5))
+    assert {:error, _errs} = Verifier.verify(TestMsg.Scalars.new(fixed32: 1.5))
+    assert {:error, _errs} = Verifier.verify(TestMsg.Scalars.new(fixed64: 1.5))
+    assert {:error, _errs} = Verifier.verify(TestMsg.Scalars.new(fixed32: 111_111_111_111))
+    assert {:error, _errs} = Verifier.verify(TestMsg.Scalars.new(sint32: 111_111_111_111))
+    assert {:error, _errs} = Verifier.verify(TestMsg.Scalars.new(sint32: "jack"))
+    assert {:error, _errs} = Verifier.verify(TestMsg.Scalars.new(sint64: :jill))
+    assert {:error, _errs} = Verifier.verify(TestMsg.Scalars.new(fixed32: <<117, 112>>))
+    assert {:error, _errs} = Verifier.verify(TestMsg.Scalars.new(fixed64: %{"the" => "hill"}))
   end
 
   test "verifies bools" do
     assert :ok == Verifier.verify(TestMsg.Scalars.new(bool: true))
     assert :ok == Verifier.verify(TestMsg.Scalars.new(bool: false))
     assert :ok == Verifier.verify(TestMsg.Scalars.new(bool: nil))
-    assert {:error, err} = Verifier.verify(TestMsg.Scalars.new(bool: -11))
-    assert err =~ ~s(-11 is invalid for type bool)
-    assert {:error, err} = Verifier.verify(TestMsg.Scalars.new(bool: "vase"))
-    assert err =~ ~s("vase" is invalid for type bool)
-    assert {:error, err} = Verifier.verify(TestMsg.Scalars.new(bool: :yarrrr))
-    assert err =~ ~s(:yarrrr is invalid for type bool)
+    assert {:error, errs} = Verifier.verify(TestMsg.Scalars.new(bool: -11))
+    assert has_single_message_matching(errs, ~s(-11 is invalid for type bool))
+    assert {:error, errs} = Verifier.verify(TestMsg.Scalars.new(bool: "vase"))
+    assert has_single_message_matching(errs, ~s("vase" is invalid for type bool))
+    assert {:error, errs} = Verifier.verify(TestMsg.Scalars.new(bool: :yarrrr))
+    assert has_single_message_matching(errs, ~s(:yarrrr is invalid for type bool))
   end
 
   test "verifies strings" do
     assert :ok == Verifier.verify(TestMsg.Foo.new(a: 42, b: 100, c: "", d: 123.5))
     assert :ok == Verifier.verify(TestMsg.Foo.new(a: 42, b: 100, c: "str", d: 123.5))
-    assert {:error, err} = Verifier.verify(TestMsg.Foo.new(a: 42, b: 100, c: false, d: 123.5))
-    assert err =~ ~s(false is invalid for type string)
-    assert {:error, err} = Verifier.verify(TestMsg.Foo.new(a: 42, b: 100, c: 555, d: 123.5))
-    assert err =~ ~s(555 is invalid for type string)
+    assert {:error, errs} = Verifier.verify(TestMsg.Foo.new(a: 42, b: 100, c: false, d: 123.5))
+    assert has_single_message_matching(errs, ~s(false is invalid for type string))
+    assert {:error, errs} = Verifier.verify(TestMsg.Foo.new(a: 42, b: 100, c: 555, d: 123.5))
+    assert has_single_message_matching(errs, ~s(555 is invalid for type string))
   end
 
   test "verifies bytes" do
     assert :ok == Verifier.verify(TestMsg.Scalars.new(bytes: "foo"))
-    assert {:error, err} = Verifier.verify(TestMsg.Scalars.new(bytes: 5.5))
-    assert err =~ ~s(5.5 is invalid for type bytes)
+    assert {:error, errs} = Verifier.verify(TestMsg.Scalars.new(bytes: 5.5))
+    assert has_single_message_matching(errs, ~s(5.5 is invalid for type bytes))
   end
 
   test "verifies enums" do
@@ -127,14 +131,29 @@ defmodule Protobuf.VerifierTest do
     assert :ok == Verifier.verify(TestMsg.Foo.new(j: :A))
     assert :ok == Verifier.verify(TestMsg.Foo.new(j: :B))
 
-    assert {:error, err} = Verifier.verify(TestMsg.Foo.new(j: :HELLO))
-    assert err =~ ~s(:HELLO is not a valid value in enum Elixir.TestMsg.EnumFoo)
-    assert {:error, err} = Verifier.verify(TestMsg.Foo.new(j: false))
-    assert err =~ ~s(false is not a valid value in enum Elixir.TestMsg.EnumFoo)
-    assert {:error, err} = Verifier.verify(TestMsg.Foo.new(j: Non.Existent.Module))
-    assert err =~ ~s(Non.Existent.Module is not a valid value in enum Elixir.TestMsg.EnumFoo)
-    assert {:error, _err} = Verifier.verify(TestMsg.Foo.new(j: "test"))
-    assert {:error, _err} = Verifier.verify(TestMsg.Foo.new(j: 200))
+    assert {:error, errs} = Verifier.verify(TestMsg.Foo.new(j: :HELLO))
+
+    assert has_single_message_matching(
+             errs,
+             ~s(:HELLO is not a valid value in enum Elixir.TestMsg.EnumFoo)
+           )
+
+    assert {:error, errs} = Verifier.verify(TestMsg.Foo.new(j: false))
+
+    assert has_single_message_matching(
+             errs,
+             ~s(false is not a valid value in enum Elixir.TestMsg.EnumFoo)
+           )
+
+    assert {:error, errs} = Verifier.verify(TestMsg.Foo.new(j: Non.Existent.Module))
+
+    assert has_single_message_matching(
+             errs,
+             ~s(Non.Existent.Module is not a valid value in enum Elixir.TestMsg.EnumFoo)
+           )
+
+    assert {:error, _errs} = Verifier.verify(TestMsg.Foo.new(j: "test"))
+    assert {:error, _errs} = Verifier.verify(TestMsg.Foo.new(j: 200))
   end
 
   test "verifies enum with lowercase atoms" do
@@ -144,31 +163,39 @@ defmodule Protobuf.VerifierTest do
     assert :ok == Verifier.verify(TestMsg.Atom.Bar2.new(b: :B))
     assert :ok == Verifier.verify(TestMsg.Atom.Bar2.new(b: :b))
     assert :ok == Verifier.verify(TestMsg.Atom.Bar2.new(a: nil, b: nil))
-    assert {:error, err} = Verifier.verify(TestMsg.Atom.Bar2.new(a: :abcdef))
+    assert {:error, errs} = Verifier.verify(TestMsg.Atom.Bar2.new(a: :abcdef))
 
     # This error message isn't ideal, but I'm not sure it's worth threading through the uncapitalized value
-    assert err =~ ~s(:ABCDEF is not a valid value in enum Elixir.TestMsg.EnumFoo)
-    assert {:error, err} = Verifier.verify(TestMsg.Atom.Bar2.new(b: :abcdef))
-    assert err =~ ~s(:ABCDEF is not a valid value in enum Elixir.TestMsg.EnumFoo)
+    assert has_single_message_matching(
+             errs,
+             ~s(:ABCDEF is not a valid value in enum Elixir.TestMsg.EnumFoo)
+           )
+
+    assert {:error, errs} = Verifier.verify(TestMsg.Atom.Bar2.new(b: :abcdef))
+
+    assert has_single_message_matching(
+             errs,
+             ~s(:ABCDEF is not a valid value in enum Elixir.TestMsg.EnumFoo)
+           )
   end
 
   test "verifies repeated enum fields" do
     assert :ok == Verifier.verify(TestMsg.Foo.new(o: [:A, :B]))
     assert :ok == Verifier.verify(TestMsg.Foo.new(o: []))
     assert :ok == Verifier.verify(TestMsg.Foo.new(o: nil))
-    assert {:error, _err} = Verifier.verify(TestMsg.Foo.new(o: [:bob, :B]))
-    assert {:error, _err} = Verifier.verify(TestMsg.Foo.new(o: [:A, :bob]))
-    assert {:error, _err} = Verifier.verify(TestMsg.Foo.new(o: [:bob, :bob]))
+    assert {:error, _errs} = Verifier.verify(TestMsg.Foo.new(o: [:bob, :B]))
+    assert {:error, _errs} = Verifier.verify(TestMsg.Foo.new(o: [:A, :bob]))
+    assert {:error, _errs} = Verifier.verify(TestMsg.Foo.new(o: [:bob, :bob]))
   end
 
   test "verifies map types" do
     assert :ok == Verifier.verify(TestMsg.Foo.new(l: %{"foo_key" => 213}))
-    assert {:error, _err} = Verifier.verify(TestMsg.Foo.new(l: "boo"))
-    assert {:error, _err} = Verifier.verify(TestMsg.Foo.new(l: ["hoo"]))
+    assert {:error, _errs} = Verifier.verify(TestMsg.Foo.new(l: "boo"))
+    assert {:error, _errs} = Verifier.verify(TestMsg.Foo.new(l: ["hoo"]))
     # the field "l" is a map from string to int32
-    assert {:error, _err} = Verifier.verify(TestMsg.Foo.new(l: %{"foo_key" => "blah"}))
-    assert {:error, _err} = Verifier.verify(TestMsg.Foo.new(l: %{123 => "blah"}))
-    assert {:error, _err} = Verifier.verify(TestMsg.Foo.new(l: %{"foo_key" => 111_111_111_111}))
+    assert {:error, _errs} = Verifier.verify(TestMsg.Foo.new(l: %{"foo_key" => "blah"}))
+    assert {:error, _errs} = Verifier.verify(TestMsg.Foo.new(l: %{123 => "blah"}))
+    assert {:error, _errs} = Verifier.verify(TestMsg.Foo.new(l: %{"foo_key" => 111_111_111_111}))
   end
 
   test "verifies oneof fields" do
@@ -182,15 +209,17 @@ defmodule Protobuf.VerifierTest do
                TestMsg.Oneof.new(%{first: {:b, "abc"}, second: {:c, 123}, other: "other"})
              )
 
-    assert {:error, err} =
+    assert {:error, errs} =
              Verifier.verify(
                TestMsg.Oneof.new(%{first: "not-in-a-tuple", second: {:c, 123}, other: "other"})
              )
 
-    assert err ==
+    assert has_single_message_matching(
+             errs,
              "TestMsg.Oneof#first has the wrong structure: the value of a oneof field should be nil or {key, val} where key = atom of a field name inside the oneof and val = its value"
+           )
 
-    assert {:error, _err} =
+    assert {:error, _errs} =
              Verifier.verify(
                TestMsg.Oneof.new(%{first: {:b, "abc"}, second: false, other: "other"})
              )
@@ -204,7 +233,7 @@ defmodule Protobuf.VerifierTest do
                )
              )
 
-    assert {:error, _err} =
+    assert {:error, _errs} =
              Verifier.verify(
                Google.Protobuf.Struct.new(
                  fields: %{"valid" => Google.Protobuf.Value.new(kind: 555)}
@@ -218,32 +247,35 @@ defmodule Protobuf.VerifierTest do
                Google.Protobuf.Struct.new(fields: %{"valid" => %{kind: {:bool_value, true}}})
              )
 
-    assert {:error, err} =
+    assert {:error, errs} =
              Verifier.verify(Google.Protobuf.Struct.new(fields: %{"valid" => %{kind: "foobar"}}))
 
-    assert err =~ "value of a oneof field should be nil or {key, val}"
+    assert has_single_message_matching(errs, "value of a oneof field should be nil or {key, val}")
   end
 
   test "verifies embedded messages" do
     assert :ok ==
              Verifier.verify(TestMsg.Foo.new(a: 42, e: %TestMsg.Foo.Bar{a: 12, b: "abc"}, f: 13))
 
-    assert {:error, err} =
+    assert {:error, errs} =
              Verifier.verify(
                TestMsg.Foo.new(a: 42, e: %TestMsg.Foo.Bar{a: true, b: "abc"}, f: 13)
              )
 
-    assert err =~ ~s(true is invalid for type int32)
+    assert has_single_message_matching(errs, ~s(true is invalid for type int32))
 
-    assert {:error, err} =
+    assert {:error, errs} =
              Verifier.verify(TestMsg.Foo.new(a: 42, e: %TestMsg.Foo.Bar{a: 12, b: 55.5}, f: 13))
 
-    assert err =~ ~s(55.5 is invalid for type string)
+    assert has_single_message_matching(errs, ~s(55.5 is invalid for type string))
 
     # wrong type of embedded message
-    assert {:error, err} = Verifier.verify(TestMsg.Foo.new(e: TestMsg.Foo2.new()))
+    assert {:error, errs} = Verifier.verify(TestMsg.Foo.new(e: TestMsg.Foo2.new()))
 
-    assert err =~ ~s(got Elixir.TestMsg.Foo2 but expected Elixir.TestMsg.Foo.Bar)
+    assert has_single_message_matching(
+             errs,
+             ~s(got Elixir.TestMsg.Foo2 but expected Elixir.TestMsg.Foo.Bar)
+           )
   end
 
   test "verifies repeated embedded fields" do
@@ -256,19 +288,19 @@ defmodule Protobuf.VerifierTest do
              Verifier.verify(TestMsg.Foo.new(h: [TestMsg.Foo.Bar.new(), TestMsg.Foo.Bar.new()]))
 
     # wrong type of embedded message
-    assert {:error, _err} =
+    assert {:error, _errs} =
              Verifier.verify(TestMsg.Foo.new(h: [TestMsg.Foo2.new(), TestMsg.Foo.Bar.new()]))
 
-    assert {:error, _err} =
+    assert {:error, _errs} =
              Verifier.verify(TestMsg.Foo.new(h: [TestMsg.Foo.Bar.new(), TestMsg.Foo2.new()]))
 
     # wrong field inside one of the embedded messages
-    assert {:error, _err} =
+    assert {:error, _errs} =
              Verifier.verify(
                TestMsg.Foo.new(h: [TestMsg.Foo.Bar.new(a: "bob"), TestMsg.Foo.Bar.new()])
              )
 
-    assert {:error, _err} =
+    assert {:error, _errs} =
              Verifier.verify(
                TestMsg.Foo.new(h: [TestMsg.Foo.Bar.new(), TestMsg.Foo.Bar.new(b: 555)])
              )
@@ -285,8 +317,8 @@ defmodule Protobuf.VerifierTest do
                )
              )
 
-    assert {:error, _err} = Verifier.verify(TestMsg.Ext.DualUseCase.new(a: false))
-    assert {:error, _err} = Verifier.verify(TestMsg.Ext.DualUseCase.new(a: 123))
+    assert {:error, _errs} = Verifier.verify(TestMsg.Ext.DualUseCase.new(a: false))
+    assert {:error, _errs} = Verifier.verify(TestMsg.Ext.DualUseCase.new(a: 123))
 
     # NOTE: maybe we can phase out the "When extype option is present, new
     # expects unwrapped value, not struct" warning now that we have new_and_verify!
@@ -302,14 +334,26 @@ defmodule Protobuf.VerifierTest do
     assert :ok == Verifier.verify(TestMsg.Ext.Timestamps.new(b: nil))
     assert :ok == Verifier.verify(TestMsg.Ext.Timestamps.new(a: DateTime.utc_now()))
     assert :ok == Verifier.verify(TestMsg.Ext.Timestamps.new(b: NaiveDateTime.utc_now()))
-    assert {:error, err} = Verifier.verify(TestMsg.Ext.Timestamps.new(a: NaiveDateTime.utc_now()))
-    assert err =~ "non-DateTime value for a timestamp field with extype DateTime.t()"
-    assert {:error, err} = Verifier.verify(TestMsg.Ext.Timestamps.new(b: DateTime.utc_now()))
-    assert err =~ "non-NaiveDateTime value for a timestamp field with extype NaiveDateTime.t()"
-    assert {:error, _err} = Verifier.verify(TestMsg.Ext.Timestamps.new(a: "lenny"))
-    assert {:error, _err} = Verifier.verify(TestMsg.Ext.Timestamps.new(b: "carl"))
-    assert {:error, _err} = Verifier.verify(TestMsg.Ext.Timestamps.new(a: 123))
-    assert {:error, _err} = Verifier.verify(TestMsg.Ext.Timestamps.new(b: 321))
+
+    assert {:error, errs} =
+             Verifier.verify(TestMsg.Ext.Timestamps.new(a: NaiveDateTime.utc_now()))
+
+    assert has_single_message_matching(
+             errs,
+             "non-DateTime value for a timestamp field with extype DateTime.t()"
+           )
+
+    assert {:error, errs} = Verifier.verify(TestMsg.Ext.Timestamps.new(b: DateTime.utc_now()))
+
+    assert has_single_message_matching(
+             errs,
+             "non-NaiveDateTime value for a timestamp field with extype NaiveDateTime.t()"
+           )
+
+    assert {:error, _errs} = Verifier.verify(TestMsg.Ext.Timestamps.new(a: "lenny"))
+    assert {:error, _errs} = Verifier.verify(TestMsg.Ext.Timestamps.new(b: "carl"))
+    assert {:error, _errs} = Verifier.verify(TestMsg.Ext.Timestamps.new(a: 123))
+    assert {:error, _errs} = Verifier.verify(TestMsg.Ext.Timestamps.new(b: 321))
   end
 
   describe "new_and_verify!/1" do

--- a/test/protobuf/verifier_test.exs
+++ b/test/protobuf/verifier_test.exs
@@ -1,0 +1,252 @@
+defmodule Protobuf.VerifierTest do
+  use ExUnit.Case, async: true
+
+  alias Protobuf.Verifier
+
+  test "verifies int32s" do
+    assert :ok == Verifier.verify(TestMsg.Foo.new(a: 42))
+    assert {:error, err} = Verifier.verify(TestMsg.Foo.new(a: "bar"))
+    assert err =~ ~s("bar" is invalid for type int32)
+    assert {:error, err} = Verifier.verify(TestMsg.Foo.new(a: 111_111_111_111))
+    assert err =~ ~s(111111111111 is invalid for type int32)
+    assert {:error, err} = Verifier.verify(TestMsg.Foo.new(a: 3.14))
+    assert err =~ ~s(3.14 is invalid for type int32)
+  end
+
+  # TestMsg.Scalars has a bunch of fields with the same name as their types
+  test "verifies int64s" do
+    assert :ok == Verifier.verify(TestMsg.Scalars.new(int64: -200))
+    assert {:error, err} = Verifier.verify(TestMsg.Scalars.new(int64: :test))
+    assert err =~ ~s(:test is invalid for type int64)
+  end
+
+  test "verifies uint32s" do
+    assert :ok == Verifier.verify(TestMsg.Scalars.new(uint32: 11))
+    assert {:error, err} = Verifier.verify(TestMsg.Scalars.new(uint32: -11))
+    assert err =~ ~s(-11 is invalid for type uint32)
+    assert {:error, err} = Verifier.verify(TestMsg.Scalars.new(uint32: 111_111_111_111))
+    assert err =~ ~s(111111111111 is invalid for type uint32)
+  end
+
+  test "verifies uint64s" do
+    assert :ok == Verifier.verify(TestMsg.Scalars.new(uint64: 11))
+    assert {:error, err} = Verifier.verify(TestMsg.Scalars.new(uint64: -11))
+    assert err =~ ~s(-11 is invalid for type uint64)
+    assert {:error, err} = Verifier.verify(TestMsg.Scalars.new(uint64: 1.5))
+    assert err =~ ~s(1.5 is invalid for type uint64)
+  end
+
+  test "verifies floats and doubles" do
+    assert :ok == Verifier.verify(TestMsg.Scalars.new(float: 11))
+    assert :ok == Verifier.verify(TestMsg.Scalars.new(double: 11))
+    assert :ok == Verifier.verify(TestMsg.Scalars.new(float: 11.333))
+    assert :ok == Verifier.verify(TestMsg.Scalars.new(double: 11.333))
+    assert :ok == Verifier.verify(TestMsg.Scalars.new(float: :infinity))
+    assert :ok == Verifier.verify(TestMsg.Scalars.new(double: :infinity))
+    assert :ok == Verifier.verify(TestMsg.Scalars.new(float: :negative_infinity))
+    assert :ok == Verifier.verify(TestMsg.Scalars.new(double: :negative_infinity))
+    assert :ok == Verifier.verify(TestMsg.Scalars.new(float: :nan))
+    assert :ok == Verifier.verify(TestMsg.Scalars.new(double: :nan))
+    assert {:error, _err} = Verifier.verify(TestMsg.Scalars.new(float: "bob"))
+    assert {:error, _err} = Verifier.verify(TestMsg.Scalars.new(double: "bob"))
+    assert {:error, _err} = Verifier.verify(TestMsg.Scalars.new(float: true))
+    assert {:error, _err} = Verifier.verify(TestMsg.Scalars.new(double: false))
+  end
+
+  test "verifies other numeric types" do
+    assert :ok == Verifier.verify(TestMsg.Scalars.new(sint32: 11))
+    assert :ok == Verifier.verify(TestMsg.Scalars.new(sint64: 11))
+    assert :ok == Verifier.verify(TestMsg.Scalars.new(fixed32: 11))
+    assert :ok == Verifier.verify(TestMsg.Scalars.new(sfixed32: 11))
+    assert :ok == Verifier.verify(TestMsg.Scalars.new(fixed64: 11))
+    assert :ok == Verifier.verify(TestMsg.Scalars.new(sfixed64: 11))
+    assert {:error, _err} = Verifier.verify(TestMsg.Scalars.new(fixed32: -11))
+    assert {:error, _err} = Verifier.verify(TestMsg.Scalars.new(fixed64: -11))
+    assert {:error, _err} = Verifier.verify(TestMsg.Scalars.new(sint32: 1.5))
+    assert {:error, _err} = Verifier.verify(TestMsg.Scalars.new(sint64: 1.5))
+    assert {:error, _err} = Verifier.verify(TestMsg.Scalars.new(fixed32: 1.5))
+    assert {:error, _err} = Verifier.verify(TestMsg.Scalars.new(fixed64: 1.5))
+    assert {:error, _err} = Verifier.verify(TestMsg.Scalars.new(fixed32: 111_111_111_111))
+    assert {:error, _err} = Verifier.verify(TestMsg.Scalars.new(sint32: 111_111_111_111))
+    assert {:error, _err} = Verifier.verify(TestMsg.Scalars.new(fixed32: 111_111_111_111))
+  end
+
+  test "verifies bools" do
+    assert :ok == Verifier.verify(TestMsg.Scalars.new(bool: true))
+    assert :ok == Verifier.verify(TestMsg.Scalars.new(bool: false))
+    assert :ok == Verifier.verify(TestMsg.Scalars.new(bool: nil))
+    assert {:error, err} = Verifier.verify(TestMsg.Scalars.new(bool: -11))
+    assert err =~ ~s(-11 is invalid for type bool)
+    assert {:error, err} = Verifier.verify(TestMsg.Scalars.new(bool: "foo"))
+    assert err =~ ~s("foo" is invalid for type bool)
+    assert {:error, err} = Verifier.verify(TestMsg.Scalars.new(bool: :yarrrr))
+    assert err =~ ~s(:yarrrr is invalid for type bool)
+  end
+
+  test "verifies strings" do
+    assert :ok == Verifier.verify(TestMsg.Foo.new(a: 42, b: 100, c: "", d: 123.5))
+    assert :ok == Verifier.verify(TestMsg.Foo.new(a: 42, b: 100, c: "str", d: 123.5))
+    assert {:error, err} = Verifier.verify(TestMsg.Foo.new(a: 42, b: 100, c: false, d: 123.5))
+    assert err =~ ~s(false is invalid for type string)
+    assert {:error, err} = Verifier.verify(TestMsg.Foo.new(a: 42, b: 100, c: 555, d: 123.5))
+    assert err =~ ~s(555 is invalid for type string)
+  end
+
+  test "verifies bytes" do
+    assert :ok == Verifier.verify(TestMsg.Scalars.new(bytes: "foo"))
+    assert {:error, err} = Verifier.verify(TestMsg.Scalars.new(bytes: 5.5))
+    assert err =~ ~s(5.5 is invalid for type bytes)
+  end
+
+  test "verifies enums" do
+    assert :ok == Verifier.verify(TestMsg.Foo.new(j: 2))
+    assert :ok == Verifier.verify(TestMsg.Foo.new(j: :A))
+    assert :ok == Verifier.verify(TestMsg.Foo.new(j: :B))
+
+    assert {:error, err} = Verifier.verify(TestMsg.Foo.new(j: :HELLO))
+    assert err =~ ~s(:HELLO is not a valid value in enum Elixir.TestMsg.EnumFoo)
+    assert {:error, err} = Verifier.verify(TestMsg.Foo.new(j: false))
+    assert err =~ ~s(false is not a valid value in enum Elixir.TestMsg.EnumFoo)
+    assert {:error, err} = Verifier.verify(TestMsg.Foo.new(j: Non.Existent.Module))
+    assert err =~ ~s(Non.Existent.Module is not a valid value in enum Elixir.TestMsg.EnumFoo)
+    assert {:error, _err} = Verifier.verify(TestMsg.Foo.new(j: "test"))
+    assert {:error, _err} = Verifier.verify(TestMsg.Foo.new(j: 200))
+  end
+
+  test "verifies enum with lowercase atoms" do
+    assert :ok == Verifier.verify(TestMsg.Atom.Bar2.new(a: :unknown))
+    assert :ok == Verifier.verify(TestMsg.Atom.Bar2.new(a: :A))
+    assert :ok == Verifier.verify(TestMsg.Atom.Bar2.new(a: :a))
+    assert :ok == Verifier.verify(TestMsg.Atom.Bar2.new(b: :B))
+    assert :ok == Verifier.verify(TestMsg.Atom.Bar2.new(b: :b))
+    assert :ok == Verifier.verify(TestMsg.Atom.Bar2.new(a: nil, b: nil))
+    assert {:error, err} = Verifier.verify(TestMsg.Atom.Bar2.new(a: :abcdef))
+
+    # This error message isn't ideal, but I'm not sure it's worth threading through the uncapitalized value
+    assert err =~ ~s(:ABCDEF is not a valid value in enum Elixir.TestMsg.EnumFoo)
+    assert {:error, err} = Verifier.verify(TestMsg.Atom.Bar2.new(b: :abcdef))
+    assert err =~ ~s(:ABCDEF is not a valid value in enum Elixir.TestMsg.EnumFoo)
+  end
+
+  test "verifies repeated enum fields" do
+    assert :ok == Verifier.verify(TestMsg.Foo.new(o: [:A, :B]))
+    assert {:error, _err} = Verifier.verify(TestMsg.Foo.new(o: [:bob, :B]))
+    assert {:error, _err} = Verifier.verify(TestMsg.Foo.new(o: [:A, :bob]))
+    assert {:error, _err} = Verifier.verify(TestMsg.Foo.new(o: [:bob, :bob]))
+  end
+
+  test "verifies map types" do
+    assert :ok == Verifier.verify(TestMsg.Foo.new(l: %{"foo_key" => 213}))
+    assert {:error, _err} = Verifier.verify(TestMsg.Foo.new(l: "boo"))
+    # TODO: handle cases like TestMsg.Foo.new(l: ["hoo"]) better
+  end
+
+  test "verifies oneof fields" do
+    assert :ok ==
+             Verifier.verify(
+               TestMsg.Oneof.new(%{first: {:a, 42}, second: {:d, "abc"}, other: "other"})
+             )
+
+    assert :ok ==
+             Verifier.verify(
+               TestMsg.Oneof.new(%{first: {:b, "abc"}, second: {:c, 123}, other: "other"})
+             )
+
+    assert {:error, err} =
+             Verifier.verify(
+               TestMsg.Oneof.new(%{first: "not-in-a-tuple", second: {:c, 123}, other: "other"})
+             )
+
+    assert err =
+             "TestMsg.Oneof field first has the wrong structure: the value of an oneof field should be {key, val} or nil"
+
+    assert {:error, _err} =
+             Verifier.verify(
+               TestMsg.Oneof.new(%{first: {:b, "abc"}, second: false, other: "other"})
+             )
+  end
+
+  test "verifies map with oneof" do
+    assert :ok ==
+             Verifier.verify(
+               Google.Protobuf.Struct.new(fields: %{"valid" => %{kind: {:bool_value, true}}})
+             )
+
+    assert {:error, _err} =
+             Verifier.verify(Google.Protobuf.Struct.new(fields: %{"valid" => %{kind: 555}}))
+  end
+
+  test "verifies embedded messages" do
+    assert :ok ==
+             Verifier.verify(TestMsg.Foo.new(a: 42, e: %TestMsg.Foo.Bar{a: 12, b: "abc"}, f: 13))
+
+    assert {:error, err} =
+             Verifier.verify(
+               TestMsg.Foo.new(a: 42, e: %TestMsg.Foo.Bar{a: true, b: "abc"}, f: 13)
+             )
+
+    assert err =~ ~s(true is invalid for type int32)
+
+    assert {:error, err} =
+             Verifier.verify(TestMsg.Foo.new(a: 42, e: %TestMsg.Foo.Bar{a: 12, b: 55.5}, f: 13))
+
+    assert err =~ ~s(55.5 is invalid for type string)
+  end
+
+  test "verifies repeated embedded fields" do
+    assert :ok ==
+             Verifier.verify(
+               TestMsg.Foo.new(h: [%TestMsg.Foo.Bar{a: 12, b: "abc"}, TestMsg.Foo.Bar.new(a: 13)])
+             )
+
+    assert :ok ==
+             Verifier.verify(TestMsg.Foo.new(h: [TestMsg.Foo.Bar.new(), TestMsg.Foo.Bar.new()]))
+
+    assert {:error, _err} =
+             Verifier.verify(
+               TestMsg.Foo.new(h: [TestMsg.Foo.Bar.new(a: "bob"), TestMsg.Foo.Bar.new()])
+             )
+
+    assert {:error, _err} =
+             Verifier.verify(
+               TestMsg.Foo.new(h: [TestMsg.Foo.Bar.new(), TestMsg.Foo.Bar.new(b: 555)])
+             )
+  end
+
+  test "verifies fields with extype annotation" do
+    assert :ok == Verifier.verify(TestMsg.Ext.DualUseCase.new(a: "s1"))
+
+    assert :ok ==
+             Verifier.verify(
+               TestMsg.Ext.DualUseCase.new(
+                 a: "s1",
+                 b: Google.Protobuf.StringValue.new(value: "s2")
+               )
+             )
+
+    assert {:error, _err} = Verifier.verify(TestMsg.Ext.DualUseCase.new(a: false))
+    assert {:error, _err} = Verifier.verify(TestMsg.Ext.DualUseCase.new(a: 123))
+
+    # NOTE: maybe we can phase out the "When extype option is present, new
+    # expects unwrapped value, not struct" warning now that we have new_and_verify!
+    assert_raise RuntimeError, fn ->
+      Verifier.verify(
+        TestMsg.Ext.DualUseCase.new(a: Google.Protobuf.StringValue.new(value: "s1"))
+      )
+    end
+  end
+
+  describe "new_and_verify!/1" do
+    test "new_and_verify!/1 builds struct" do
+      result = TestMsg.Foo.Bar.new_and_verify!(a: 20, b: "test")
+      assert result.a == 20
+      assert result.b == "test"
+    end
+
+    test "raises on invalid value" do
+      assert_raise Protobuf.VerificationError, fn ->
+        TestMsg.Foo.new_and_verify!(j: :invalid_value)
+      end
+    end
+  end
+end

--- a/test/protobuf/verifier_test.exs
+++ b/test/protobuf/verifier_test.exs
@@ -5,27 +5,46 @@ defmodule Protobuf.VerifierTest do
 
   test "verifies int32s" do
     assert :ok == Verifier.verify(TestMsg.Foo.new(a: 42))
-    assert {:error, err} = Verifier.verify(TestMsg.Foo.new(a: "bar"))
-    assert err =~ ~s("bar" is invalid for type int32)
+    assert :ok == Verifier.verify(TestMsg.Foo.new(a: nil))
+    assert :ok == Verifier.verify(TestMsg.Foo.new(a: -42))
+    assert :ok == Verifier.verify(TestMsg.Foo.new(a: 0))
+    assert {:error, err} = Verifier.verify(TestMsg.Foo.new(a: "candle"))
+    assert err =~ ~s("candle" is invalid for type int32)
     assert {:error, err} = Verifier.verify(TestMsg.Foo.new(a: 111_111_111_111))
     assert err =~ ~s(111111111111 is invalid for type int32)
     assert {:error, err} = Verifier.verify(TestMsg.Foo.new(a: 3.14))
     assert err =~ ~s(3.14 is invalid for type int32)
+    assert {:error, _err} = Verifier.verify(TestMsg.Foo.new(a: false))
+    assert {:error, _err} = Verifier.verify(TestMsg.Foo.new(a: :enum_value))
+    assert {:error, _err} = Verifier.verify(TestMsg.Foo.new(a: TestMsg.Foo))
+    assert {:error, _err} = Verifier.verify(TestMsg.Foo.new(a: TestMsg.Foo.new()))
   end
 
   # TestMsg.Scalars has a bunch of fields with the same name as their types
   test "verifies int64s" do
     assert :ok == Verifier.verify(TestMsg.Scalars.new(int64: -200))
+    assert :ok == Verifier.verify(TestMsg.Scalars.new(int64: 140))
+    assert :ok == Verifier.verify(TestMsg.Scalars.new(int64: 0))
+    assert :ok == Verifier.verify(TestMsg.Scalars.new(int64: 9_223_372_036_854_775_807))
+    assert :ok == Verifier.verify(TestMsg.Scalars.new(int64: nil))
     assert {:error, err} = Verifier.verify(TestMsg.Scalars.new(int64: :test))
     assert err =~ ~s(:test is invalid for type int64)
+    assert {:error, _err} = Verifier.verify(TestMsg.Scalars.new(int64: "broom"))
+    assert {:error, _err} = Verifier.verify(TestMsg.Scalars.new(int64: TestMsg.Foo.Bar.new()))
+    assert {:error, _err} = Verifier.verify(TestMsg.Scalars.new(int64: ["chair"]))
+    assert {:error, _err} = Verifier.verify(TestMsg.Scalars.new(int64: {:pillow}))
   end
 
   test "verifies uint32s" do
     assert :ok == Verifier.verify(TestMsg.Scalars.new(uint32: 11))
+    assert :ok == Verifier.verify(TestMsg.Scalars.new(uint32: 4_294_967_295))
+    assert :ok == Verifier.verify(TestMsg.Scalars.new(uint32: 0))
     assert {:error, err} = Verifier.verify(TestMsg.Scalars.new(uint32: -11))
     assert err =~ ~s(-11 is invalid for type uint32)
-    assert {:error, err} = Verifier.verify(TestMsg.Scalars.new(uint32: 111_111_111_111))
-    assert err =~ ~s(111111111111 is invalid for type uint32)
+    assert {:error, err} = Verifier.verify(TestMsg.Scalars.new(uint32: 4_294_967_296))
+    assert err =~ ~s(4294967296 is invalid for type uint32)
+    assert {:error, _err} = Verifier.verify(TestMsg.Scalars.new(uint32: 0.5))
+    assert {:error, _err} = Verifier.verify(TestMsg.Scalars.new(uint32: "shoe"))
   end
 
   test "verifies uint64s" do
@@ -34,6 +53,8 @@ defmodule Protobuf.VerifierTest do
     assert err =~ ~s(-11 is invalid for type uint64)
     assert {:error, err} = Verifier.verify(TestMsg.Scalars.new(uint64: 1.5))
     assert err =~ ~s(1.5 is invalid for type uint64)
+    assert {:error, _err} = Verifier.verify(TestMsg.Scalars.new(uint64: :blah))
+    assert {:error, _err} = Verifier.verify(TestMsg.Scalars.new(uint64: "book"))
   end
 
   test "verifies floats and doubles" do
@@ -47,8 +68,8 @@ defmodule Protobuf.VerifierTest do
     assert :ok == Verifier.verify(TestMsg.Scalars.new(double: :negative_infinity))
     assert :ok == Verifier.verify(TestMsg.Scalars.new(float: :nan))
     assert :ok == Verifier.verify(TestMsg.Scalars.new(double: :nan))
-    assert {:error, _err} = Verifier.verify(TestMsg.Scalars.new(float: "bob"))
-    assert {:error, _err} = Verifier.verify(TestMsg.Scalars.new(double: "bob"))
+    assert {:error, _err} = Verifier.verify(TestMsg.Scalars.new(float: "rug"))
+    assert {:error, _err} = Verifier.verify(TestMsg.Scalars.new(double: "table"))
     assert {:error, _err} = Verifier.verify(TestMsg.Scalars.new(float: true))
     assert {:error, _err} = Verifier.verify(TestMsg.Scalars.new(double: false))
   end
@@ -68,7 +89,10 @@ defmodule Protobuf.VerifierTest do
     assert {:error, _err} = Verifier.verify(TestMsg.Scalars.new(fixed64: 1.5))
     assert {:error, _err} = Verifier.verify(TestMsg.Scalars.new(fixed32: 111_111_111_111))
     assert {:error, _err} = Verifier.verify(TestMsg.Scalars.new(sint32: 111_111_111_111))
-    assert {:error, _err} = Verifier.verify(TestMsg.Scalars.new(fixed32: 111_111_111_111))
+    assert {:error, _err} = Verifier.verify(TestMsg.Scalars.new(sint32: "jack"))
+    assert {:error, _err} = Verifier.verify(TestMsg.Scalars.new(sint64: :jill))
+    assert {:error, _err} = Verifier.verify(TestMsg.Scalars.new(fixed32: <<117, 112>>))
+    assert {:error, _err} = Verifier.verify(TestMsg.Scalars.new(fixed64: %{"the" => "hill"}))
   end
 
   test "verifies bools" do
@@ -77,8 +101,8 @@ defmodule Protobuf.VerifierTest do
     assert :ok == Verifier.verify(TestMsg.Scalars.new(bool: nil))
     assert {:error, err} = Verifier.verify(TestMsg.Scalars.new(bool: -11))
     assert err =~ ~s(-11 is invalid for type bool)
-    assert {:error, err} = Verifier.verify(TestMsg.Scalars.new(bool: "foo"))
-    assert err =~ ~s("foo" is invalid for type bool)
+    assert {:error, err} = Verifier.verify(TestMsg.Scalars.new(bool: "vase"))
+    assert err =~ ~s("vase" is invalid for type bool)
     assert {:error, err} = Verifier.verify(TestMsg.Scalars.new(bool: :yarrrr))
     assert err =~ ~s(:yarrrr is invalid for type bool)
   end
@@ -130,6 +154,8 @@ defmodule Protobuf.VerifierTest do
 
   test "verifies repeated enum fields" do
     assert :ok == Verifier.verify(TestMsg.Foo.new(o: [:A, :B]))
+    assert :ok == Verifier.verify(TestMsg.Foo.new(o: []))
+    assert :ok == Verifier.verify(TestMsg.Foo.new(o: nil))
     assert {:error, _err} = Verifier.verify(TestMsg.Foo.new(o: [:bob, :B]))
     assert {:error, _err} = Verifier.verify(TestMsg.Foo.new(o: [:A, :bob]))
     assert {:error, _err} = Verifier.verify(TestMsg.Foo.new(o: [:bob, :bob]))
@@ -138,7 +164,11 @@ defmodule Protobuf.VerifierTest do
   test "verifies map types" do
     assert :ok == Verifier.verify(TestMsg.Foo.new(l: %{"foo_key" => 213}))
     assert {:error, _err} = Verifier.verify(TestMsg.Foo.new(l: "boo"))
-    # TODO: handle cases like TestMsg.Foo.new(l: ["hoo"]) better
+    assert {:error, _err} = Verifier.verify(TestMsg.Foo.new(l: ["hoo"]))
+    # the field "l" is a map from string to int32
+    assert {:error, _err} = Verifier.verify(TestMsg.Foo.new(l: %{"foo_key" => "blah"}))
+    assert {:error, _err} = Verifier.verify(TestMsg.Foo.new(l: %{123 => "blah"}))
+    assert {:error, _err} = Verifier.verify(TestMsg.Foo.new(l: %{"foo_key" => 111_111_111_111}))
   end
 
   test "verifies oneof fields" do
@@ -157,8 +187,8 @@ defmodule Protobuf.VerifierTest do
                TestMsg.Oneof.new(%{first: "not-in-a-tuple", second: {:c, 123}, other: "other"})
              )
 
-    assert err =
-             "TestMsg.Oneof field first has the wrong structure: the value of an oneof field should be {key, val} or nil"
+    assert err ==
+             "TestMsg.Oneof#first has the wrong structure: the value of a oneof field should be nil or {key, val} where key = atom of a field name inside the oneof and val = its value"
 
     assert {:error, _err} =
              Verifier.verify(
@@ -169,11 +199,29 @@ defmodule Protobuf.VerifierTest do
   test "verifies map with oneof" do
     assert :ok ==
              Verifier.verify(
-               Google.Protobuf.Struct.new(fields: %{"valid" => %{kind: {:bool_value, true}}})
+               Google.Protobuf.Struct.new(
+                 fields: %{"valid" => Google.Protobuf.Value.new(kind: {:bool_value, true})}
+               )
              )
 
     assert {:error, _err} =
-             Verifier.verify(Google.Protobuf.Struct.new(fields: %{"valid" => %{kind: 555}}))
+             Verifier.verify(
+               Google.Protobuf.Struct.new(
+                 fields: %{"valid" => Google.Protobuf.Value.new(kind: 555)}
+               )
+             )
+  end
+
+  test "supports map syntax for submessages" do
+    assert :ok ==
+             Verifier.verify(
+               Google.Protobuf.Struct.new(fields: %{"valid" => %{kind: {:bool_value, true}}})
+             )
+
+    assert {:error, err} =
+             Verifier.verify(Google.Protobuf.Struct.new(fields: %{"valid" => %{kind: "foobar"}}))
+
+    assert err =~ "value of a oneof field should be nil or {key, val}"
   end
 
   test "verifies embedded messages" do
@@ -191,6 +239,11 @@ defmodule Protobuf.VerifierTest do
              Verifier.verify(TestMsg.Foo.new(a: 42, e: %TestMsg.Foo.Bar{a: 12, b: 55.5}, f: 13))
 
     assert err =~ ~s(55.5 is invalid for type string)
+
+    # wrong type of embedded message
+    assert {:error, err} = Verifier.verify(TestMsg.Foo.new(e: TestMsg.Foo2.new()))
+
+    assert err =~ ~s(got Elixir.TestMsg.Foo2 but expected Elixir.TestMsg.Foo.Bar)
   end
 
   test "verifies repeated embedded fields" do
@@ -202,6 +255,14 @@ defmodule Protobuf.VerifierTest do
     assert :ok ==
              Verifier.verify(TestMsg.Foo.new(h: [TestMsg.Foo.Bar.new(), TestMsg.Foo.Bar.new()]))
 
+    # wrong type of embedded message
+    assert {:error, _err} =
+             Verifier.verify(TestMsg.Foo.new(h: [TestMsg.Foo2.new(), TestMsg.Foo.Bar.new()]))
+
+    assert {:error, _err} =
+             Verifier.verify(TestMsg.Foo.new(h: [TestMsg.Foo.Bar.new(), TestMsg.Foo2.new()]))
+
+    # wrong field inside one of the embedded messages
     assert {:error, _err} =
              Verifier.verify(
                TestMsg.Foo.new(h: [TestMsg.Foo.Bar.new(a: "bob"), TestMsg.Foo.Bar.new()])

--- a/test/protobuf/verifier_test.exs
+++ b/test/protobuf/verifier_test.exs
@@ -297,6 +297,21 @@ defmodule Protobuf.VerifierTest do
     end
   end
 
+  test "verifies timestamp fields with extype option" do
+    assert :ok == Verifier.verify(TestMsg.Ext.Timestamps.new(a: nil))
+    assert :ok == Verifier.verify(TestMsg.Ext.Timestamps.new(b: nil))
+    assert :ok == Verifier.verify(TestMsg.Ext.Timestamps.new(a: DateTime.utc_now()))
+    assert :ok == Verifier.verify(TestMsg.Ext.Timestamps.new(b: NaiveDateTime.utc_now()))
+    assert {:error, err} = Verifier.verify(TestMsg.Ext.Timestamps.new(a: NaiveDateTime.utc_now()))
+    assert err =~ "non-DateTime value for a timestamp field with extype DateTime.t()"
+    assert {:error, err} = Verifier.verify(TestMsg.Ext.Timestamps.new(b: DateTime.utc_now()))
+    assert err =~ "non-NaiveDateTime value for a timestamp field with extype NaiveDateTime.t()"
+    assert {:error, _err} = Verifier.verify(TestMsg.Ext.Timestamps.new(a: "lenny"))
+    assert {:error, _err} = Verifier.verify(TestMsg.Ext.Timestamps.new(b: "carl"))
+    assert {:error, _err} = Verifier.verify(TestMsg.Ext.Timestamps.new(a: 123))
+    assert {:error, _err} = Verifier.verify(TestMsg.Ext.Timestamps.new(b: 321))
+  end
+
   describe "new_and_verify!/1" do
     test "new_and_verify!/1 builds struct" do
       result = TestMsg.Foo.Bar.new_and_verify!(a: 20, b: "test")

--- a/test/protobuf/verifier_test.exs
+++ b/test/protobuf/verifier_test.exs
@@ -13,11 +13,11 @@ defmodule Protobuf.VerifierTest do
     assert :ok == Verifier.verify(TestMsg.Foo.new(a: -42))
     assert :ok == Verifier.verify(TestMsg.Foo.new(a: 0))
     assert {:error, errs} = Verifier.verify(TestMsg.Foo.new(a: "candle"))
-    assert has_single_message_matching(errs, ~s("candle" is invalid for type int32))
+    assert has_single_message_matching(errs, ~s(invalid value for type int32))
     assert {:error, errs} = Verifier.verify(TestMsg.Foo.new(a: 111_111_111_111))
-    assert has_single_message_matching(errs, ~s(111111111111 is invalid for type int32))
+    assert has_single_message_matching(errs, ~s(invalid value for type int32))
     assert {:error, errs} = Verifier.verify(TestMsg.Foo.new(a: 3.14))
-    assert has_single_message_matching(errs, ~s(3.14 is invalid for type int32))
+    assert has_single_message_matching(errs, ~s(invalid value for type int32))
     assert {:error, _errs} = Verifier.verify(TestMsg.Foo.new(a: false))
     assert {:error, _errs} = Verifier.verify(TestMsg.Foo.new(a: :enum_value))
     assert {:error, _errs} = Verifier.verify(TestMsg.Foo.new(a: TestMsg.Foo))
@@ -32,7 +32,7 @@ defmodule Protobuf.VerifierTest do
     assert :ok == Verifier.verify(TestMsg.Scalars.new(int64: 9_223_372_036_854_775_807))
     assert :ok == Verifier.verify(TestMsg.Scalars.new(int64: nil))
     assert {:error, errs} = Verifier.verify(TestMsg.Scalars.new(int64: :test))
-    assert has_single_message_matching(errs, ~s(:test is invalid for type int64))
+    assert has_single_message_matching(errs, ~s(invalid value for type int64))
     assert {:error, _errs} = Verifier.verify(TestMsg.Scalars.new(int64: "broom"))
     assert {:error, _errs} = Verifier.verify(TestMsg.Scalars.new(int64: TestMsg.Foo.Bar.new()))
     assert {:error, _errs} = Verifier.verify(TestMsg.Scalars.new(int64: ["chair"]))
@@ -44,9 +44,9 @@ defmodule Protobuf.VerifierTest do
     assert :ok == Verifier.verify(TestMsg.Scalars.new(uint32: 4_294_967_295))
     assert :ok == Verifier.verify(TestMsg.Scalars.new(uint32: 0))
     assert {:error, errs} = Verifier.verify(TestMsg.Scalars.new(uint32: -11))
-    assert has_single_message_matching(errs, ~s(-11 is invalid for type uint32))
+    assert has_single_message_matching(errs, ~s(invalid value for type uint32))
     assert {:error, errs} = Verifier.verify(TestMsg.Scalars.new(uint32: 4_294_967_296))
-    assert has_single_message_matching(errs, ~s(4294967296 is invalid for type uint32))
+    assert has_single_message_matching(errs, ~s(invalid value for type uint32))
     assert {:error, _errs} = Verifier.verify(TestMsg.Scalars.new(uint32: 0.5))
     assert {:error, _errs} = Verifier.verify(TestMsg.Scalars.new(uint32: "shoe"))
   end
@@ -54,9 +54,9 @@ defmodule Protobuf.VerifierTest do
   test "verifies uint64s" do
     assert :ok == Verifier.verify(TestMsg.Scalars.new(uint64: 11))
     assert {:error, errs} = Verifier.verify(TestMsg.Scalars.new(uint64: -11))
-    assert has_single_message_matching(errs, ~s(-11 is invalid for type uint64))
+    assert has_single_message_matching(errs, ~s(invalid value for type uint64))
     assert {:error, errs} = Verifier.verify(TestMsg.Scalars.new(uint64: 1.5))
-    assert has_single_message_matching(errs, ~s(1.5 is invalid for type uint64))
+    assert has_single_message_matching(errs, ~s(invalid value for type uint64))
     assert {:error, _errs} = Verifier.verify(TestMsg.Scalars.new(uint64: :blah))
     assert {:error, _errs} = Verifier.verify(TestMsg.Scalars.new(uint64: "book"))
   end
@@ -104,26 +104,26 @@ defmodule Protobuf.VerifierTest do
     assert :ok == Verifier.verify(TestMsg.Scalars.new(bool: false))
     assert :ok == Verifier.verify(TestMsg.Scalars.new(bool: nil))
     assert {:error, errs} = Verifier.verify(TestMsg.Scalars.new(bool: -11))
-    assert has_single_message_matching(errs, ~s(-11 is invalid for type bool))
+    assert has_single_message_matching(errs, ~s(invalid value for type bool))
     assert {:error, errs} = Verifier.verify(TestMsg.Scalars.new(bool: "vase"))
-    assert has_single_message_matching(errs, ~s("vase" is invalid for type bool))
+    assert has_single_message_matching(errs, ~s(invalid value for type bool))
     assert {:error, errs} = Verifier.verify(TestMsg.Scalars.new(bool: :yarrrr))
-    assert has_single_message_matching(errs, ~s(:yarrrr is invalid for type bool))
+    assert has_single_message_matching(errs, ~s(invalid value for type bool))
   end
 
   test "verifies strings" do
     assert :ok == Verifier.verify(TestMsg.Foo.new(a: 42, b: 100, c: "", d: 123.5))
     assert :ok == Verifier.verify(TestMsg.Foo.new(a: 42, b: 100, c: "str", d: 123.5))
     assert {:error, errs} = Verifier.verify(TestMsg.Foo.new(a: 42, b: 100, c: false, d: 123.5))
-    assert has_single_message_matching(errs, ~s(false is invalid for type string))
+    assert has_single_message_matching(errs, ~s(invalid value for type string))
     assert {:error, errs} = Verifier.verify(TestMsg.Foo.new(a: 42, b: 100, c: 555, d: 123.5))
-    assert has_single_message_matching(errs, ~s(555 is invalid for type string))
+    assert has_single_message_matching(errs, ~s(invalid value for type string))
   end
 
   test "verifies bytes" do
     assert :ok == Verifier.verify(TestMsg.Scalars.new(bytes: "foo"))
     assert {:error, errs} = Verifier.verify(TestMsg.Scalars.new(bytes: 5.5))
-    assert has_single_message_matching(errs, ~s(5.5 is invalid for type bytes))
+    assert has_single_message_matching(errs, ~s(invalid value for type bytes))
   end
 
   test "verifies enums" do
@@ -135,21 +135,21 @@ defmodule Protobuf.VerifierTest do
 
     assert has_single_message_matching(
              errs,
-             ~s(:HELLO is not a valid value in enum Elixir.TestMsg.EnumFoo)
+             ~s(invalid value for enum Elixir.TestMsg.EnumFoo)
            )
 
     assert {:error, errs} = Verifier.verify(TestMsg.Foo.new(j: false))
 
     assert has_single_message_matching(
              errs,
-             ~s(false is not a valid value in enum Elixir.TestMsg.EnumFoo)
+             ~s(invalid value for enum Elixir.TestMsg.EnumFoo)
            )
 
     assert {:error, errs} = Verifier.verify(TestMsg.Foo.new(j: Non.Existent.Module))
 
     assert has_single_message_matching(
              errs,
-             ~s(Non.Existent.Module is not a valid value in enum Elixir.TestMsg.EnumFoo)
+             ~s(invalid value for enum Elixir.TestMsg.EnumFoo)
            )
 
     assert {:error, _errs} = Verifier.verify(TestMsg.Foo.new(j: "test"))
@@ -168,14 +168,14 @@ defmodule Protobuf.VerifierTest do
     # This error message isn't ideal, but I'm not sure it's worth threading through the uncapitalized value
     assert has_single_message_matching(
              errs,
-             ~s(:ABCDEF is not a valid value in enum Elixir.TestMsg.EnumFoo)
+             ~s(invalid value for enum Elixir.TestMsg.EnumFoo)
            )
 
     assert {:error, errs} = Verifier.verify(TestMsg.Atom.Bar2.new(b: :abcdef))
 
     assert has_single_message_matching(
              errs,
-             ~s(:ABCDEF is not a valid value in enum Elixir.TestMsg.EnumFoo)
+             ~s(invalid value for enum Elixir.TestMsg.EnumFoo)
            )
   end
 
@@ -262,12 +262,12 @@ defmodule Protobuf.VerifierTest do
                TestMsg.Foo.new(a: 42, e: %TestMsg.Foo.Bar{a: true, b: "abc"}, f: 13)
              )
 
-    assert has_single_message_matching(errs, ~s(true is invalid for type int32))
+    assert has_single_message_matching(errs, ~s(invalid value for type int32))
 
     assert {:error, errs} =
              Verifier.verify(TestMsg.Foo.new(a: 42, e: %TestMsg.Foo.Bar{a: 12, b: 55.5}, f: 13))
 
-    assert has_single_message_matching(errs, ~s(55.5 is invalid for type string))
+    assert has_single_message_matching(errs, ~s(invalid value for type string))
 
     # wrong type of embedded message
     assert {:error, errs} = Verifier.verify(TestMsg.Foo.new(e: TestMsg.Foo2.new()))

--- a/test/support/test_msg.ex
+++ b/test/support/test_msg.ex
@@ -346,6 +346,10 @@ defmodule TestMsg do
     defstruct [:a, :b]
 
     field :a, 1, optional: true, type: Google.Protobuf.Timestamp, options: [extype: "DateTime.t"]
-    field :b, 2, optional: true, type: Google.Protobuf.Timestamp, options: [extype: "NaiveDateTime.t"]
+
+    field :b, 2,
+      optional: true,
+      type: Google.Protobuf.Timestamp,
+      options: [extype: "NaiveDateTime.t"]
   end
 end

--- a/test/support/test_msg.ex
+++ b/test/support/test_msg.ex
@@ -334,4 +334,18 @@ defmodule TestMsg do
     field :a, 1, optional: true, type: Google.Protobuf.StringValue
     field :b, 2, optional: true, type: Google.Protobuf.StringValue
   end
+
+  defmodule Ext.Timestamps do
+    @moduledoc false
+    use Protobuf, syntax: :proto3
+
+    @type t :: %__MODULE__{
+            a: DateTime.t() | nil,
+            b: NaiveDateTime.t() | nil
+          }
+    defstruct [:a, :b]
+
+    field :a, 1, optional: true, type: Google.Protobuf.Timestamp, options: [extype: "DateTime.t"]
+    field :b, 2, optional: true, type: Google.Protobuf.Timestamp, options: [extype: "NaiveDateTime.t"]
+  end
 end


### PR DESCRIPTION
With protobuf-elixir, you can use `new()` to create new proto structs:

```
MyMessage.new(
  string_field: "foobar",
)
```

One problem is you can put random keys that aren't in the message in `new()` and they'll be silently dropped, which is annoying when you have a typo. That's what `new!()` solves. But `new!()` doesn't complain when you use bad values:

```
MyMessage.new!(
  string_field: true,
)
# builds a struct, then an error happens later during encoding
```

That's what `new_and_verify!()` is meant to catch.

```
MyMessage.new_and_verify!(
  string_field: true,
)
# immediately throws an exception
```

This implementation handles a decent number of cases. Couple of areas where it could be improved. 

Context:
- https://brex.slack.com/archives/CQURSQW94/p1593120167014600
- https://brex.slack.com/archives/CQURSQW94/p1596667463299000