### PR TITLE
add fullname message prop

### DIFF
--- a/lib/protobuf.ex
+++ b/lib/protobuf.ex
@@ -39,6 +39,7 @@ defmodule Protobuf do
       Module.register_attribute(__MODULE__, :extends, accumulate: true)
       Module.register_attribute(__MODULE__, :extensions, [])
       Module.register_attribute(__MODULE__, :msg_options, accumulate: true)
+      Module.register_attribute(__MODULE__, :full_name, accumulate: true)
 
       @options unquote(opts)
       @before_compile Protobuf.DSL

--- a/lib/protobuf/message_props.ex
+++ b/lib/protobuf/message_props.ex
@@ -16,7 +16,8 @@ defmodule Protobuf.MessageProps do
           extendable?: boolean,
           map?: boolean,
           extension_range: [{non_neg_integer, non_neg_integer}],
-          options: Keyword.t() | nil
+          options: Keyword.t() | nil,
+          full_name: String.t()
         }
   defstruct ordered_tags: [],
             tags_map: %{},
@@ -30,5 +31,6 @@ defmodule Protobuf.MessageProps do
             extendable?: false,
             map?: false,
             extension_range: [],
-            options: nil
+            options: nil,
+            full_name: ""
 end


### PR DESCRIPTION
add full_name into msg_props, so that we could get the full name (derived from module name) by:
`Ext.MyMessage.__message_props__.full_name`