### PR TITLE
 [PROTO-10] Simplify Google Wrappers encoding/decoding 

### DIFF
--- a/lib/protobuf/extype/wrappers.ex
+++ b/lib/protobuf/extype/wrappers.ex
@@ -14,9 +14,7 @@ defimpl Extype.Protocol,
     Implement value unwrapping for Google Wrappers.
   """
 
-  require Protobuf.Decoder
   require Logger
-  import Protobuf.Decoder, only: [decode_zigzag: 1]
 
   def validate_and_to_atom_extype!(Google.Protobuf.DoubleValue, "float"), do: :double
   def validate_and_to_atom_extype!(Google.Protobuf.FloatValue, "float"), do: :float
@@ -43,15 +41,14 @@ defimpl Extype.Protocol,
     end
   end
 
-  def encode_type(type, v, extype) do
-    fnum = type.__message_props__.field_props[1].encoded_fnum
-    encoded = Protobuf.Encoder.encode_type(extype, v)
-    IO.iodata_to_binary([[fnum, encoded]])
+  def encode_type(type, v, _extype) do
+    val = type.new(value: v)
+    Protobuf.Encoder.encode(type, val, iolist: true)
   end
 
-  def decode_type(_type, val, extype) do
-    [_tag, _wire, val | _rest] = Protobuf.Decoder.decode_raw(val)
-    Protobuf.Decoder.decode_type_m(extype, :value, val)
+  def decode_type(type, val, _extype) do
+    %{value: value} = Protobuf.Decoder.decode(val, type)
+    value
   end
 
   def verify_type(_type, v, extype) do

--- a/test/protobuf/decoder_test.exs
+++ b/test/protobuf/decoder_test.exs
@@ -175,6 +175,16 @@ defmodule Protobuf.DecoderTest do
              TestMsg.Ext.DualNonUse.new(a: nil, b: Google.Protobuf.StringValue.new(value: "s2"))
   end
 
+  test "decode with and without custom field options, default" do
+    bin = <<10, 0>>
+
+    assert Decoder.decode(bin, TestMsg.Ext.DualUseCase) ==
+             TestMsg.Ext.DualUseCase.new(a: "")
+
+    assert Decoder.decode(bin, TestMsg.Ext.DualNonUse) ==
+             TestMsg.Ext.DualNonUse.new(a: Google.Protobuf.StringValue.new(value: ""))
+  end
+
   describe "groups" do
     test "skips all groups and their fields" do
       a = <<8, 42>>

--- a/test/protobuf/encoder_test.exs
+++ b/test/protobuf/encoder_test.exs
@@ -204,4 +204,14 @@ defmodule Protobuf.EncoderTest do
     msg = TestMsg.Ext.DualUseCase.new(b: Google.Protobuf.StringValue.new(value: "s2"))
     assert Encoder.encode(msg) == <<18, 4, 10, 2, 115, 50>>
   end
+
+  test "encoding with custom field options, default" do
+    msg = TestMsg.Ext.DualUseCase.new(a: "")
+    assert Encoder.encode(msg) == <<10, 0>>
+  end
+
+  test "encoding with custom field options, default2" do
+    msg = TestMsg.Ext.DualNonUse.new(a: Google.Protobuf.StringValue.new(value: ""))
+    assert Encoder.encode(msg) == <<10, 0>>
+  end
 end


### PR DESCRIPTION
When the the wrapper value is the default, it is encoded differently to save space. Our custom encoding does not do this shortening. Instead of recreating the encoding and decoding logic for wrappers, just cast the values to wrapper structs and feed into existing encoding/decoding functions.

Jira: https://brexhq.atlassian.net/browse/PROTO-10