### PR TITLE
Add go_package to protos

### DIFF
--- a/src/brex_elixirpb.proto
+++ b/src/brex_elixirpb.proto
@@ -4,22 +4,26 @@ package brex.elixirpb;
 
 import "google/protobuf/descriptor.proto";
 
-option go_package = "github.com/brexhq/brex_elixirpb";
+option go_package = "github.com/brexhq/protos/brexelixir";
 
 // Sample Field Option Extension
-// Defines an extension to specify the elixir type generated for the given field.
+// Defines an extension to specify the elixir type generated for the given
+// field.
 
 // For example:
-// google.protobuf.StringValue my_string = 1 [(brex.elixirpb.field).extype="String.t"];
+// google.protobuf.StringValue my_string = 1
+// [(brex.elixirpb.field).extype="String.t"];
 
 // To compile
-//protoc --plugin=./protoc-gen-elixir  --proto_path=lib --proto_path=src --elixir_out=lib src/brex_elixirpb.proto
+// protoc --plugin=./protoc-gen-elixir  --proto_path=lib --proto_path=src
+// --elixir_out=lib src/brex_elixirpb.proto
 
 message FieldOptions {
-  // Specifies an elixir type to generate for this field. This will override usual type.
+  // Specifies an elixir type to generate for this field. This will override
+  // usual type.
   optional string extype = 1;
   // Specifies options to lowercase or deprefix enums.
-  optional string enum = 2 [deprecated=true];
+  optional string enum = 2 [ deprecated = true ];
 }
 
 extend google.protobuf.FieldOptions {
@@ -35,6 +39,4 @@ message EnumOptions {
   optional bool deprefix = 3;
 }
 
-extend google.protobuf.EnumOptions {
-  optional EnumOptions enum = 65008;
-}
+extend google.protobuf.EnumOptions { optional EnumOptions enum = 65008; }

--- a/src/brex_elixirpb.proto
+++ b/src/brex_elixirpb.proto
@@ -1,7 +1,10 @@
 syntax = "proto2";
 
 package brex.elixirpb;
+
 import "google/protobuf/descriptor.proto";
+
+option go_package = "github.com/brexhq/brex_elixirpb";
 
 // Sample Field Option Extension
 // Defines an extension to specify the elixir type generated for the given field.

--- a/src/elixirpb.proto
+++ b/src/elixirpb.proto
@@ -1,5 +1,5 @@
-// Put this file to elixirpb.proto under PROTO_PATH. See `protoc -h` for `--proto_path` option.
-// Then import it
+// Put this file to elixirpb.proto under PROTO_PATH. See `protoc -h` for
+// `--proto_path` option. Then import it
 // ````proto
 // import "elixirpb.proto";
 // ````
@@ -11,7 +11,7 @@ syntax = "proto2";
 
 package elixirpb;
 
-option go_package = "github.com/brexhq/elixirpb";
+option go_package = "github.com/brexhq/protos/elixir";
 
 import "google/protobuf/descriptor.proto";
 
@@ -27,6 +27,4 @@ message FileOptions {
   optional string module_prefix = 1;
 }
 
-extend google.protobuf.FileOptions {
-  optional FileOptions file = 1047;
-}
+extend google.protobuf.FileOptions { optional FileOptions file = 1047; }

--- a/src/elixirpb.proto
+++ b/src/elixirpb.proto
@@ -11,6 +11,8 @@ syntax = "proto2";
 
 package elixirpb;
 
+option go_package = "github.com/brexhq/elixirpb";
+
 import "google/protobuf/descriptor.proto";
 
 // File level options


### PR DESCRIPTION
Adding go_package definitions to prevent errors when using custom protoc plugins written in go.  These are set to match the values used in proto.BUILD inside `credit_card`