### PR TITLE
[WORK-877] update message options to check empty pb_extensions condition

### DIFF
--- a/lib/protobuf/protoc/generator/message.ex
+++ b/lib/protobuf/protoc/generator/message.ex
@@ -358,10 +358,6 @@ defmodule Protobuf.Protoc.Generator.Message do
 
   defp put_json_name(opts, _syntax, _props), do: opts
 
-  defp cal_message_options(%Google.Protobuf.MessageOptions{__pb_extensions__: %{}}) do
-    nil
-  end
-
   defp cal_message_options(%Google.Protobuf.MessageOptions{__pb_extensions__: pb_extensions} = options) do
     Enum.reduce(pb_extensions, [], fn {{ext_mod, name_atom}, _}, acc ->
       options
@@ -374,7 +370,12 @@ defmodule Protobuf.Protoc.Generator.Message do
           [Map.from_struct(opt) | acc]
       end
     end)
-    |> inspect(limit: :infinity)
+    |> case do
+      [] ->
+        nil
+      opts ->
+        inspect(opts, limit: :infinity)
+    end
   end
 
   defp cal_message_options(_opts) do

--- a/lib/protobuf/protoc/generator/message.ex
+++ b/lib/protobuf/protoc/generator/message.ex
@@ -358,6 +358,10 @@ defmodule Protobuf.Protoc.Generator.Message do
 
   defp put_json_name(opts, _syntax, _props), do: opts
 
+  defp cal_message_options(%Google.Protobuf.MessageOptions{__pb_extensions__: %{}}) do
+    nil
+  end
+
   defp cal_message_options(%Google.Protobuf.MessageOptions{__pb_extensions__: pb_extensions} = options) do
     Enum.reduce(pb_extensions, [], fn {{ext_mod, name_atom}, _}, acc ->
       options

--- a/test/protobuf/protoc/proto/extension3.proto
+++ b/test/protobuf/protoc/proto/extension3.proto
@@ -10,3 +10,7 @@ message MyEventMessage {
   option (brex.events.extension.message).is_event = true;
   google.protobuf.DoubleValue f1 = 1 [(brex.elixirpb.field).extype="float"];
 }
+
+message MyNonEventMessage {
+  map<string, string> args = 1;
+}

--- a/test/protobuf/protoc/proto_gen/extension3.pb.ex
+++ b/test/protobuf/protoc/proto_gen/extension3.pb.ex
@@ -19,3 +19,39 @@ defmodule Ext.MyEventMessage do
 
   field :f1, 1, type: Google.Protobuf.DoubleValue, options: [extype: "float"]
 end
+
+defmodule Ext.MyNonEventMessage.ArgsEntry do
+  @moduledoc false
+  use Protobuf, custom_field_options?: true, map: true, syntax: :proto3
+
+  @type t :: %__MODULE__{
+          key: String.t(),
+          value: String.t()
+        }
+
+  defstruct [:key, :value]
+
+  def full_name do
+    "ext.MyNonEventMessage.ArgsEntry"
+  end
+
+  field :key, 1, type: :string
+  field :value, 2, type: :string
+end
+
+defmodule Ext.MyNonEventMessage do
+  @moduledoc false
+  use Protobuf, custom_field_options?: true, syntax: :proto3
+
+  @type t :: %__MODULE__{
+          args: %{String.t() => String.t()}
+        }
+
+  defstruct [:args]
+
+  def full_name do
+    "ext.MyNonEventMessage"
+  end
+
+  field :args, 1, repeated: true, type: Ext.MyNonEventMessage.ArgsEntry, map: true
+end


### PR DESCRIPTION
In the last [PR](https://github.com/brexhq/protobuf-elixir/pull/26), we missed the case when we have `message` proto that contains `map`, which will result in generating `pb.ex `file with empty `message_options` func:
```
  def message_options do
    # credo:disable-for-next-line
    []
  end
```

As these functions do not return anything, we do not want to add the empty functions to the existing pb.ex files. This PR adds the check to avoid adding empty functions. 