### PR TITLE
add demoscene-extensions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,9 +40,11 @@ gen-protos: protoc-gen-elixir
 	protoc -I src -I test/protobuf/protoc/proto --elixir_out=custom_field_options=true:test/protobuf/protoc/proto_gen --plugin=./protoc-gen-elixir test/protobuf/protoc/proto/extension.proto
 	protoc -I src -I test/protobuf/protoc/proto --elixir_out=custom_field_options=true:test/protobuf/protoc/proto_gen --plugin=./protoc-gen-elixir test/protobuf/protoc/proto/extension2.proto
 	protoc -I src -I test/protobuf/protoc/proto --elixir_out=custom_field_options=true:test/protobuf/protoc/proto_gen --plugin=./protoc-gen-elixir test/protobuf/protoc/proto/extension3.proto
+	protoc -I src -I test/protobuf/protoc/proto --elixir_out=custom_field_options=true:test/protobuf/protoc/proto_gen --plugin=./protoc-gen-elixir test/protobuf/protoc/proto/extension4.proto
 	protoc -I src -I test/protobuf/protoc/proto --elixir_out=custom_field_options=true:test/protobuf/protoc/proto_gen --plugin=./protoc-gen-elixir test/protobuf/protoc/proto/enum_options.proto
 	protoc -I src --elixir_out=lib --plugin=./protoc-gen-elixir elixirpb.proto
 	protoc -I src --elixir_out=lib --plugin=./protoc-gen-elixir brex_elixirpb.proto
 	protoc -I src  -I test/protobuf/protoc/proto/events --elixir_out=lib --plugin=./protoc-gen-elixir brex_events_extensions.proto
+	protoc -I src  -I test/protobuf/protoc/proto/demoscene --elixir_out=lib --plugin=./protoc-gen-elixir demoscene_extensions.proto
 
 .PHONY: clean gen_google_proto gen_test_protos

--- a/lib/demoscene_extensions.pb.ex
+++ b/lib/demoscene_extensions.pb.ex
@@ -1,0 +1,38 @@
+defmodule Brex.Demoscene.Extensions.DataEnvironmentBehavior do
+  @moduledoc false
+  use Protobuf, enum: true, syntax: :proto2
+
+  @type t ::
+          integer
+          | :DATA_ENVIRONMENT_BEHAVIOR_INVALID
+          | :DATA_ENVIRONMENT_BEHAVIOR_BLOCK
+          | :DATA_ENVIRONMENT_BEHAVIOR_MOCK
+
+  field :DATA_ENVIRONMENT_BEHAVIOR_INVALID, 0
+  field :DATA_ENVIRONMENT_BEHAVIOR_BLOCK, 1
+  field :DATA_ENVIRONMENT_BEHAVIOR_MOCK, 2
+end
+
+defmodule Brex.Demoscene.Extensions.DemosceneOptions do
+  @moduledoc false
+  use Protobuf, syntax: :proto2
+
+  @type t :: %__MODULE__{
+          test_behavior: Brex.Demoscene.Extensions.DataEnvironmentBehavior.t()
+        }
+  defstruct [:test_behavior]
+
+  field :test_behavior, 1,
+    optional: true,
+    type: Brex.Demoscene.Extensions.DataEnvironmentBehavior,
+    enum: true
+end
+
+defmodule Brex.Demoscene.Extensions.PbExtension do
+  @moduledoc false
+  use Protobuf, syntax: :proto2
+
+  extend Google.Protobuf.MessageOptions, :demoscene_options, 90909,
+    optional: true,
+    type: Brex.Demoscene.Extensions.DemosceneOptions
+end

--- a/test/protobuf/protoc/proto/demoscene/demoscene_extensions.proto
+++ b/test/protobuf/protoc/proto/demoscene/demoscene_extensions.proto
@@ -1,0 +1,27 @@
+syntax = "proto2";
+
+package brex.demoscene.extensions;
+import "google/protobuf/descriptor.proto";
+
+// Demoscene Extensions
+// Allows for clients to annotate their request messages with specification for how
+// their message should be handled in in 'test' data environment contexts (i.e. demo
+// and sandbox accounts).
+// For example:
+// message PaymentRailTransfer {
+//  option (brex.demoscene.extensions.demoscene_options).test_behavior = DATA_ENVIRONMENT_BEHAVIOR_BLOCK;
+// }
+
+enum DataEnvironmentBehavior {
+  DATA_ENVIRONMENT_BEHAVIOR_INVALID = 0;
+  DATA_ENVIRONMENT_BEHAVIOR_BLOCK = 1;
+  DATA_ENVIRONMENT_BEHAVIOR_MOCK = 2;
+}
+
+message DemosceneOptions {
+  optional DataEnvironmentBehavior test_behavior = 1;
+}
+
+extend google.protobuf.MessageOptions {
+  optional DemosceneOptions demoscene_options = 90909;
+}

--- a/test/protobuf/protoc/proto/extension4.proto
+++ b/test/protobuf/protoc/proto/extension4.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+package ext;
+
+import "brex_elixirpb.proto";
+import "demoscene/demoscene_extensions.proto";
+import "google/protobuf/wrappers.proto";
+
+message MyTestBehaviorMessage {
+  option (brex.demoscene.extensions.demoscene_options).test_behavior = DATA_ENVIRONMENT_BEHAVIOR_BLOCK;
+  google.protobuf.DoubleValue f1 = 1 [(brex.elixirpb.field).extype="float"];
+}
+
+message MyNonTestBehaviorMessage {
+  map<string, string> args = 1;
+}

--- a/test/protobuf/protoc/proto_gen/extension4.pb.ex
+++ b/test/protobuf/protoc/proto_gen/extension4.pb.ex
@@ -1,0 +1,49 @@
+defmodule Ext.MyTestBehaviorMessage do
+  @moduledoc false
+  use Protobuf, custom_field_options?: true, syntax: :proto3
+
+  @type t :: %__MODULE__{
+          f1: float | nil
+        }
+  defstruct [:f1]
+
+  def full_name do
+    "ext.MyTestBehaviorMessage"
+  end
+
+  field :f1, 1, type: Google.Protobuf.DoubleValue, options: [extype: "float"]
+end
+
+defmodule Ext.MyNonTestBehaviorMessage.ArgsEntry do
+  @moduledoc false
+  use Protobuf, custom_field_options?: true, map: true, syntax: :proto3
+
+  @type t :: %__MODULE__{
+          key: String.t(),
+          value: String.t()
+        }
+  defstruct [:key, :value]
+
+  def full_name do
+    "ext.MyNonTestBehaviorMessage.ArgsEntry"
+  end
+
+  field :key, 1, type: :string
+  field :value, 2, type: :string
+end
+
+defmodule Ext.MyNonTestBehaviorMessage do
+  @moduledoc false
+  use Protobuf, custom_field_options?: true, syntax: :proto3
+
+  @type t :: %__MODULE__{
+          args: %{String.t() => String.t()}
+        }
+  defstruct [:args]
+
+  def full_name do
+    "ext.MyNonTestBehaviorMessage"
+  end
+
+  field :args, 1, repeated: true, type: Ext.MyNonTestBehaviorMessage.ArgsEntry, map: true
+end


### PR DESCRIPTION
Trying to add a new message_option for a new extension that was added [here](https://github.com/brexhq/credit_card/pull/123223/files#diff-f21d14674d3aec68a800bcb851d8d549a7b74b98a05347e4104c8eb8331ef044). The goal is that any generated `*.pb.ex` file will have a `message_options` with the appropriate `test_behavior`. Following the work [here](https://github.com/brexhq/protobuf-elixir/pull/26) with some limited success