### PR TITLE
update message_options with test_behavior

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,9 +40,11 @@ gen-protos: protoc-gen-elixir
 	protoc -I src -I test/protobuf/protoc/proto --elixir_out=custom_field_options=true:test/protobuf/protoc/proto_gen --plugin=./protoc-gen-elixir test/protobuf/protoc/proto/extension.proto
 	protoc -I src -I test/protobuf/protoc/proto --elixir_out=custom_field_options=true:test/protobuf/protoc/proto_gen --plugin=./protoc-gen-elixir test/protobuf/protoc/proto/extension2.proto
 	protoc -I src -I test/protobuf/protoc/proto --elixir_out=custom_field_options=true:test/protobuf/protoc/proto_gen --plugin=./protoc-gen-elixir test/protobuf/protoc/proto/extension3.proto
+	protoc -I src -I test/protobuf/protoc/proto --elixir_out=custom_field_options=true:test/protobuf/protoc/proto_gen --plugin=./protoc-gen-elixir test/protobuf/protoc/proto/extension4.proto
 	protoc -I src -I test/protobuf/protoc/proto --elixir_out=custom_field_options=true:test/protobuf/protoc/proto_gen --plugin=./protoc-gen-elixir test/protobuf/protoc/proto/enum_options.proto
 	protoc -I src --elixir_out=lib --plugin=./protoc-gen-elixir elixirpb.proto
 	protoc -I src --elixir_out=lib --plugin=./protoc-gen-elixir brex_elixirpb.proto
 	protoc -I src  -I test/protobuf/protoc/proto/events --elixir_out=lib --plugin=./protoc-gen-elixir brex_events_extensions.proto
+	protoc -I src  -I test/protobuf/protoc/proto/demoscene --elixir_out=custom_field_options=true:lib --plugin=./protoc-gen-elixir demoscene_extensions.proto
 
 .PHONY: clean gen_google_proto gen_test_protos

--- a/lib/demoscene_extensions.pb.ex
+++ b/lib/demoscene_extensions.pb.ex
@@ -1,0 +1,40 @@
+defmodule Brex.Demoscene.Extensions.DataEnvironmentBehavior do
+  @moduledoc false
+  use Protobuf, custom_field_options?: true, enum: true, syntax: :proto2
+
+  option enum: :atomize
+
+  @type t :: integer | :invalid | :block | :mock
+
+  field :DATA_ENVIRONMENT_BEHAVIOR_INVALID, 0
+  field :DATA_ENVIRONMENT_BEHAVIOR_BLOCK, 1
+  field :DATA_ENVIRONMENT_BEHAVIOR_MOCK, 2
+end
+
+defmodule Brex.Demoscene.Extensions.DemosceneOptions do
+  @moduledoc false
+  use Protobuf, custom_field_options?: true, syntax: :proto2
+
+  @type t :: %__MODULE__{
+          test_behavior: Brex.Demoscene.Extensions.DataEnvironmentBehavior.t()
+        }
+  defstruct [:test_behavior]
+
+  def full_name do
+    "brex.demoscene.extensions.DemosceneOptions"
+  end
+
+  field :test_behavior, 1,
+    optional: true,
+    type: Brex.Demoscene.Extensions.DataEnvironmentBehavior,
+    enum: true
+end
+
+defmodule Brex.Demoscene.Extensions.PbExtension do
+  @moduledoc false
+  use Protobuf, syntax: :proto2
+
+  extend Google.Protobuf.MessageOptions, :demoscene_options, 90909,
+    optional: true,
+    type: Brex.Demoscene.Extensions.DemosceneOptions
+end

--- a/test/protobuf/protoc/generator/message_test.exs
+++ b/test/protobuf/protoc/generator/message_test.exs
@@ -1,6 +1,7 @@
 defmodule Protobuf.Protoc.Generator.MessageTest do
   use ExUnit.Case, async: true
 
+  alias Brex.Demoscene.Extensions.DemosceneOptions
   alias Protobuf.Protoc.Context
   alias Protobuf.Protoc.Generator.Message, as: Generator
 
@@ -625,5 +626,34 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
       assert msg =~ "defstruct [:the_field_name]\n"
       assert msg =~ "field :the_field_name, 1, required: true, type: :string\n"
     end
+  end
+
+  test "generate message_options" do
+    ctx = %Context{
+      package: "",
+      custom_field_options?: true
+    }
+
+    message_options = Google.Protobuf.MessageOptions.new()
+    demoscene_options = DemosceneOptions.new(test_behavior: :block)
+
+    options =
+      Google.Protobuf.MessageOptions.put_extension(
+        message_options,
+        Brex.Demoscene.Extensions.PbExtension,
+        :demoscene_options,
+        demoscene_options
+      )
+
+    desc =
+      Google.Protobuf.DescriptorProto.new(
+        name: "Foo",
+        options: options
+      )
+
+    {[], [msg]} = Generator.generate(ctx, desc)
+    assert msg =~ "defstruct []\n"
+    assert msg =~ "def message_options do\n"
+    assert msg =~ "[%{test_behavior: :block}]"
   end
 end

--- a/test/protobuf/protoc/proto/demoscene/demoscene_extensions.proto
+++ b/test/protobuf/protoc/proto/demoscene/demoscene_extensions.proto
@@ -1,0 +1,29 @@
+syntax = "proto2";
+
+package brex.demoscene.extensions;
+import "google/protobuf/descriptor.proto";
+import "brex_elixirpb.proto";
+
+// Demoscene Extensions
+// Allows for clients to annotate their request messages with specification for how
+// their message should be handled in in 'test' data environment contexts (i.e. demo
+// and sandbox accounts).
+// For example:
+// message PaymentRailTransfer {
+//  option (brex.demoscene.extensions.demoscene_options).test_behavior = DATA_ENVIRONMENT_BEHAVIOR_BLOCK;
+// }
+
+enum DataEnvironmentBehavior {
+  option (brex.elixirpb.enum).atomize = true;
+  DATA_ENVIRONMENT_BEHAVIOR_INVALID = 0;
+  DATA_ENVIRONMENT_BEHAVIOR_BLOCK = 1;
+  DATA_ENVIRONMENT_BEHAVIOR_MOCK = 2;
+}
+
+message DemosceneOptions {
+  optional DataEnvironmentBehavior test_behavior = 1;
+}
+
+extend google.protobuf.MessageOptions {
+  optional DemosceneOptions demoscene_options = 90909;
+}

--- a/test/protobuf/protoc/proto/extension4.proto
+++ b/test/protobuf/protoc/proto/extension4.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+
+package ext;
+
+import "brex_elixirpb.proto";
+import "demoscene/demoscene_extensions.proto";
+import "google/protobuf/wrappers.proto";
+
+
+message TestBehaviorEventMessage {
+  option (brex.demoscene.extensions.demoscene_options).test_behavior = DATA_ENVIRONMENT_BEHAVIOR_BLOCK;
+  google.protobuf.DoubleValue f1 = 1 [(brex.elixirpb.field).extype="float"];
+  google.protobuf.DoubleValue f2 = 2 [(brex.elixirpb.field).extype="float"];
+}
+
+message NonTestBehaviorEventMessage {
+  map<string, string> args = 1;
+}

--- a/test/protobuf/protoc/proto_gen/extension4.pb.ex
+++ b/test/protobuf/protoc/proto_gen/extension4.pb.ex
@@ -1,0 +1,56 @@
+defmodule Ext.TestBehaviorEventMessage do
+  @moduledoc false
+  use Protobuf, custom_field_options?: true, syntax: :proto3
+
+  @type t :: %__MODULE__{
+          f1: float | nil,
+          f2: float | nil
+        }
+  defstruct [:f1, :f2]
+
+  def full_name do
+    "ext.TestBehaviorEventMessage"
+  end
+
+  def message_options do
+    # credo:disable-for-next-line
+    [%{test_behavior: :block}]
+  end
+
+  field :f1, 1, type: Google.Protobuf.DoubleValue, options: [extype: "float"]
+  field :f2, 2, type: Google.Protobuf.DoubleValue, options: [extype: "float"]
+end
+
+defmodule Ext.NonTestBehaviorEventMessage.ArgsEntry do
+  @moduledoc false
+  use Protobuf, custom_field_options?: true, map: true, syntax: :proto3
+
+  @type t :: %__MODULE__{
+          key: String.t(),
+          value: String.t()
+        }
+  defstruct [:key, :value]
+
+  def full_name do
+    "ext.NonTestBehaviorEventMessage.ArgsEntry"
+  end
+
+  field :key, 1, type: :string
+  field :value, 2, type: :string
+end
+
+defmodule Ext.NonTestBehaviorEventMessage do
+  @moduledoc false
+  use Protobuf, custom_field_options?: true, syntax: :proto3
+
+  @type t :: %__MODULE__{
+          args: %{String.t() => String.t()}
+        }
+  defstruct [:args]
+
+  def full_name do
+    "ext.NonTestBehaviorEventMessage"
+  end
+
+  field :args, 1, repeated: true, type: Ext.NonTestBehaviorEventMessage.ArgsEntry, map: true
+end


### PR DESCRIPTION
Currently, running `brexctl gen proto` with the new [test_behavior](https://github.com/brexhq/credit_card/blob/main/protos/demoscene/extensions.proto#L22) MessageOption does not update the [message_options](https://github.com/brexhq/credit_card/blob/main/protos/lib/protos/ux/teach/v1/events/seen_flag_update.pb.ex#L16) function like it does for is_event.

Following https://github.com/brexhq/protobuf-elixir/pull/26 to add a `demoscene_extensions.pb.ex`.

Was able to test by doing 
```protoc -I src  -I test/protobuf/protoc/proto/demoscene --elixir_out=custom_field_options=true:lib --plugin=./protoc-gen-elixir demoscene_extensions.proto```
And then recompiling
```
make clean && make gen-protos
```

The generated `extension4.pb.ex` file has `test_behavior` in its `message_options`.